### PR TITLE
Fix decoration positioning for nested functions

### DIFF
--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -37,7 +37,8 @@ async function updateDecorations(
       lineContent.includes(pattern)
     );
     // if we encounter an unrecognized pattern, just use the beginning of the line
-    const startPosition = matchingPattern?.length ?? 0;
+    const patternIndex = matchingPattern ? lineContent.indexOf(matchingPattern) : -1;
+    const startPosition = patternIndex !== -1 ? patternIndex + matchingPattern!.length : 0;
 
     const range = new vscode.Range(
       line,


### PR DESCRIPTION
Fixes a bug where sparkle ✨ and cross 🚫 decorations were incorrectly positioned when functions are nested inside blocks (if statements, loops, etc.) due to indentation.

The decoration positioning logic was using only the pattern length to calculate where to place decorations, ignoring the actual position of the pattern within the line. This caused decorations to appear at incorrect positions for indented code:

```ts
// Top-level function - decoration positioned correctly
function ✨ topLevel() {
  return <div>Hello</div>;
}

// Nested function - decoration positioned incorrectly
if (true) {
  functi ✨on nestedFunction() {  // ✨ appeared at position 8 instead of 10
    return <div>Nested</div>;
  }
}
```

This fixes the startPosition to account for the index in which the pattern appears in the line.

(Note I authored this commit with Copilot Agent)