### PR TITLE
Include a preview link for compiled output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project follows [Semantic Versioning](https://semver.org).
 ### Added
 - Added "Fix with AI" button for failed optimizations
 - Added command to reveal the selection that caused the failure
+- Added "Preview compiled output" link in hover tooltips for successfully optimized components
 
 ### Fixed
 -  

--- a/src/decorations.ts
+++ b/src/decorations.ts
@@ -61,7 +61,10 @@ async function updateDecorations(
     if (log.kind === "CompileSuccess") {
       // Use hoverMessage for displaying Markdown tooltips
       hoverMessage.appendMarkdown(
-        "✨ This component has been auto-memoized by React Compiler."
+        "✨ This component has been auto-memoized by React Compiler.\n\n"
+      );
+      hoverMessage.appendMarkdown(
+        `**[Preview compiled output 📄](command:react-compiler-marker.previewCompiled)**`
       );
     } else {
       hoverMessage.appendMarkdown(
@@ -100,10 +103,10 @@ async function updateDecorations(
         })
       )}`;
       hoverMessage.appendMarkdown(` **[Fix with AI 🤖💬](${fixWithAICmd})**`);
-
-      // Allow the hover link to be trusted
-      hoverMessage.isTrusted = true;
     }
+
+    // Allow the hover link to be trusted
+    hoverMessage.isTrusted = true;
 
     return { range, hoverMessage };
   });


### PR DESCRIPTION
Result:

<img width="751" height="132" alt="CleanShot 2025-10-20 at 18 23 03" src="https://github.com/user-attachments/assets/4bf838e6-3604-43b1-bf9d-f98299087fef" />
