### PR TITLE
Enhance configuration options by adding `babelPluginPath` to specify the location of the babel-plugin-react-compiler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project follows [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 ### Added
-- 
+- Added `babelPluginPath` configuration option to specify a directory where the babel-plugin-react-compiler is located. By default it's `node_modules/babel-plugin-react-compiler`.
 
 ### Fixed
 -  

--- a/package.json
+++ b/package.json
@@ -55,7 +55,17 @@
         "title": "Preview Compiled Output",
         "category": "React Compiler Marker ✨"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "React Compiler Marker",
+      "properties": {
+        "reactCompilerMarker.babelPluginPath": {
+          "type": "string",
+          "default": "node_modules/babel-plugin-react-compiler",
+          "description": "Path to the babel-plugin-react-compiler in your project. By default it's 'node_modules/babel-plugin-react-compiler'"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/checkReactCompiler.ts
+++ b/src/checkReactCompiler.ts
@@ -110,10 +110,16 @@ export function checkReactCompiler(sourceCode: string, filename: string) {
 
   try {
     const workspacePath = workspaceFolder.uri.fsPath;
-    const nodeModulesPath = path.join(workspacePath, "node_modules");
-    BabelPluginReactCompiler = require(
-      path.join(nodeModulesPath, "babel-plugin-react-compiler")
+    const config = vscode.workspace.getConfiguration("reactCompilerMarker");
+    const babelPluginPath = config.get<string>(
+      "babelPluginPath",
+      "node_modules/babel-plugin-react-compiler"
     );
+
+    BabelPluginReactCompiler = require(path.join(
+      workspacePath,
+      babelPluginPath
+    ));
   } catch (error: any) {
     failToLoadBabelPluginError(error);
     try {
@@ -153,9 +159,10 @@ export async function getCompiledOutput(
   try {
     const workspacePath = workspaceFolder.uri.fsPath;
     const nodeModulesPath = path.join(workspacePath, "node_modules");
-    BabelPluginReactCompiler = require(
-      path.join(nodeModulesPath, "babel-plugin-react-compiler")
-    );
+    BabelPluginReactCompiler = require(path.join(
+      nodeModulesPath,
+      "babel-plugin-react-compiler"
+    ));
   } catch (error: any) {
     failToLoadBabelPluginError(error);
     try {


### PR DESCRIPTION
Addresses https://github.com/blazejkustra/react-compiler-marker/issues/22