### PR TITLE
Add respectGitignore option to skip gitignored files during report generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8108,6 +8108,7 @@
         "@babel/parser": "^7.26.2",
         "@babel/preset-typescript": "^7.26.0",
         "babel-plugin-react-compiler": "1.0.0",
+        "ignore": "^7.0.3",
         "vscode-languageserver": "^9.0.1",
         "vscode-languageserver-textdocument": "^1.0.12"
       },
@@ -8117,6 +8118,15 @@
       "devDependencies": {
         "@types/babel__core": "^7.20.5",
         "@types/node": "20.x"
+      }
+    },
+    "packages/server/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "packages/vscode-client": {

--- a/packages/intellij-client/CHANGELOG.md
+++ b/packages/intellij-client/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to the React Compiler Marker WebStorm/IntelliJ plugin will b
 
 ## [Unreleased]
 ### Added
-- **Report generation and visualization**: Generate a project-wide report of React Compiler optimization results, displayed in an interactive webview with a tree view of files and components
-- **"Fix with AI" button in report webview**: Generates a markdown file listing all failed components with their error locations and reasons, including AI instructions for fixing them
+- **Respect .gitignore**: New setting to honor .gitignore rules when scanning files for report generation (enabled by default)
 
 ---
 

--- a/packages/intellij-client/README.md
+++ b/packages/intellij-client/README.md
@@ -65,6 +65,7 @@ Go to **Settings/Preferences** → **Languages & Frameworks** → **React Compil
 - **Success Emoji**: Emoji shown for optimized components (default: ✨)
 - **Error Emoji**: Emoji shown for failed components (default: 🚫)
 - **Babel Plugin Path**: Path to babel-plugin-react-compiler (default: `node_modules/babel-plugin-react-compiler`)
+- **Respect .gitignore**: Honor .gitignore rules when scanning files for report generation (default: enabled)
 
 ## How It Works
 
@@ -119,5 +120,6 @@ See at a glance which components are automatically memoized with ✨ markers, id
 - **Success Emoji**: Customize the marker for optimized components (default: ✨)
 - **Error Emoji**: Customize the marker for failed components (default: 🚫)
 - **Babel Plugin Path**: Set custom path to babel-plugin-react-compiler
+- **Respect .gitignore**: Honor .gitignore rules when scanning files for reports (default: enabled)
 
 <!-- Plugin description end -->

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/actions/GenerateReportAction.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/actions/GenerateReportAction.kt
@@ -49,6 +49,7 @@ class GenerateReportAction : AnAction() {
             "headExtra" to headExtra,
             "excludeDirs" to settings.excludedDirectoriesList,
             "includeExtensions" to settings.supportedExtensionsList,
+            "respectGitignore" to settings.respectGitignore,
             "emojis" to mapOf(
                 "success" to settings.successEmoji,
                 "error" to settings.errorEmoji

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerConfigurable.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerConfigurable.kt
@@ -18,6 +18,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
     private var babelPluginPathField: JBTextField? = null
     private var excludedDirectoriesField: JBTextField? = null
     private var supportedExtensionsField: JBTextField? = null
+    private var respectGitignoreCheckbox: JBCheckBox? = null
 
     override fun getDisplayName(): String = "React Compiler Marker"
 
@@ -28,6 +29,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         babelPluginPathField = JBTextField()
         excludedDirectoriesField = JBTextField()
         supportedExtensionsField = JBTextField()
+        respectGitignoreCheckbox = JBCheckBox("Respect .gitignore rules when scanning")
 
         return FormBuilder.createFormBuilder()
             .addComponent(enabledCheckbox!!)
@@ -39,6 +41,8 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
             .addSeparator()
             .addLabeledComponent(JBLabel("Excluded directories (comma-separated):"), excludedDirectoriesField!!, 1, false)
             .addLabeledComponent(JBLabel("Supported extensions (comma-separated):"), supportedExtensionsField!!, 1, false)
+            .addSeparator()
+            .addComponent(respectGitignoreCheckbox!!)
             .addComponentFillVertically(JPanel(), 0)
             .panel
     }
@@ -50,7 +54,8 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
                errorEmojiField?.text != settings.errorEmoji ||
                babelPluginPathField?.text != settings.babelPluginPath ||
                excludedDirectoriesField?.text != settings.excludedDirectories ||
-               supportedExtensionsField?.text != settings.supportedExtensions
+               supportedExtensionsField?.text != settings.supportedExtensions ||
+               respectGitignoreCheckbox?.isSelected != settings.respectGitignore
     }
 
     override fun apply() {
@@ -61,6 +66,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         settings.babelPluginPath = babelPluginPathField?.text ?: "node_modules/babel-plugin-react-compiler"
         settings.excludedDirectories = excludedDirectoriesField?.text ?: ""
         settings.supportedExtensions = supportedExtensionsField?.text ?: ""
+        settings.respectGitignore = respectGitignoreCheckbox?.isSelected ?: true
 
         // Update LSP server configuration
         val lspManager = ReactCompilerLspServerManager.getInstance(project)
@@ -75,6 +81,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         babelPluginPathField?.text = settings.babelPluginPath
         excludedDirectoriesField?.text = settings.excludedDirectories
         supportedExtensionsField?.text = settings.supportedExtensions
+        respectGitignoreCheckbox?.isSelected = settings.respectGitignore
     }
 
     override fun disposeUIResources() {
@@ -84,5 +91,6 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         babelPluginPathField = null
         excludedDirectoriesField = null
         supportedExtensionsField = null
+        respectGitignoreCheckbox = null
     }
 }

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerSettings.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerSettings.kt
@@ -20,6 +20,7 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
         var babelPluginPath: String = "node_modules/babel-plugin-react-compiler"
         var excludedDirectories: String = "node_modules, .git, dist, build, out, coverage, .next, .turbo"
         var supportedExtensions: String = ".js, .jsx, .ts, .tsx, .mjs, .cjs"
+        var respectGitignore: Boolean = true
     }
 
     override fun getState(): State = myState
@@ -64,6 +65,12 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
             myState.supportedExtensions = value
         }
 
+    var respectGitignore: Boolean
+        get() = myState.respectGitignore
+        set(value) {
+            myState.respectGitignore = value
+        }
+
     val excludedDirectoriesList: List<String>
         get() = excludedDirectories.split(",").map { it.trim() }.filter { it.isNotEmpty() }
 
@@ -75,7 +82,8 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
         "errorEmoji" to errorEmoji,
         "babelPluginPath" to babelPluginPath,
         "excludedDirectories" to excludedDirectoriesList,
-        "supportedExtensions" to supportedExtensionsList
+        "supportedExtensions" to supportedExtensionsList,
+        "respectGitignore" to respectGitignore
     )
 
     companion object {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     "@babel/parser": "^7.26.2",
     "@babel/preset-typescript": "^7.26.0",
     "babel-plugin-react-compiler": "1.0.0",
+    "ignore": "^7.0.3",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"
   },

--- a/packages/server/src/report/generate.ts
+++ b/packages/server/src/report/generate.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import type { Dirent } from "fs";
 import os from "os";
 import path from "path";
+import ignore, { type Ignore } from "ignore";
 import { checkReactCompiler, LoggerEvent } from "../checkReactCompiler";
 
 /**
@@ -42,6 +43,8 @@ export interface ReportOptions {
   includeExtensions?: string[];
   /** Directory names to skip at any depth (e.g. ["node_modules"]). */
   excludeDirs?: string[];
+  /** Whether to respect .gitignore rules when scanning (default: true). */
+  respectGitignore?: boolean;
   /** Optional progress callback for reporting processed file counts. */
   onProgress?: (progress: ReportProgress) => void;
 }
@@ -78,20 +81,51 @@ function shouldSkipDir(dirName: string, excludeDirs: Set<string>): boolean {
 }
 
 /**
- * Recursively list source files under a root, honoring extension and exclude filters.
+ * Read .gitignore patterns from a directory, returning an empty array if none exists.
+ */
+async function loadGitignorePatterns(dir: string): Promise<string[]> {
+  try {
+    const content = await fs.readFile(path.join(dir, ".gitignore"), "utf8");
+    return content.split("\n");
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Recursively list source files under a root, honoring extension, exclude, and .gitignore filters.
  */
 async function listSourceFiles(
   root: string,
   includeExtensions: Set<string>,
-  excludeDirs: Set<string>
+  excludeDirs: Set<string>,
+  respectGitignore: boolean
 ): Promise<string[]> {
   const files: string[] = [];
   const queue: string[] = [root];
+
+  let ig: Ignore | undefined;
+  if (respectGitignore) {
+    ig = ignore();
+    const rootPatterns = await loadGitignorePatterns(root);
+    if (rootPatterns.length > 0) {
+      ig.add(rootPatterns);
+    }
+  }
 
   while (queue.length > 0) {
     const current = queue.pop();
     if (!current) {
       continue;
+    }
+
+    // Load nested .gitignore rules
+    if (ig && current !== root) {
+      const nestedPatterns = await loadGitignorePatterns(current);
+      if (nestedPatterns.length > 0) {
+        const relDir = path.relative(root, current);
+        ig.add(nestedPatterns.map((p) => (p.trim() ? path.posix.join(relDir, p) : p)));
+      }
     }
 
     let entries: Dirent[];
@@ -103,13 +137,23 @@ async function listSourceFiles(
 
     for (const entry of entries) {
       const fullPath = path.join(current, entry.name);
+      const relativePath = path.relative(root, fullPath).split(path.sep).join("/");
+
       if (entry.isDirectory()) {
-        if (!shouldSkipDir(entry.name, excludeDirs)) {
-          queue.push(fullPath);
+        if (shouldSkipDir(entry.name, excludeDirs)) {
+          continue;
         }
+        // For directories, ignore expects a trailing slash
+        if (ig && ig.ignores(relativePath + "/")) {
+          continue;
+        }
+        queue.push(fullPath);
         continue;
       }
       if (!entry.isFile()) {
+        continue;
+      }
+      if (ig && ig.ignores(relativePath)) {
         continue;
       }
       if (isSourceFile(fullPath, includeExtensions)) {
@@ -152,8 +196,9 @@ export async function generateReport(options: ReportOptions): Promise<ReactCompi
   const includeExtensions = new Set(options.includeExtensions ?? Array.from(DEFAULT_EXTENSIONS));
   const excludeDirs = new Set(options.excludeDirs ?? Array.from(DEFAULT_EXCLUDES));
   const maxConcurrency = options.maxConcurrency ?? Math.max(1, os.cpus().length - 1);
+  const respectGitignore = options.respectGitignore ?? true;
 
-  const files = await listSourceFiles(root, includeExtensions, excludeDirs);
+  const files = await listSourceFiles(root, includeExtensions, excludeDirs, respectGitignore);
   const totalFiles = files.length;
   let processed = 0;
   let lastProgressAt = 0;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -316,6 +316,7 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
           maxConcurrency: options?.maxConcurrency,
           includeExtensions: options?.includeExtensions,
           excludeDirs: options?.excludeDirs,
+          respectGitignore: options?.respectGitignore,
           onProgress: reportId
             ? (progress) => {
                 connection.sendNotification("react-compiler-marker/reportProgress", {
@@ -350,6 +351,7 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
           maxConcurrency: htmlOptions?.maxConcurrency,
           includeExtensions: htmlOptions?.includeExtensions,
           excludeDirs: htmlOptions?.excludeDirs,
+          respectGitignore: htmlOptions?.respectGitignore,
           onProgress: htmlReportId
             ? (progress) => {
                 connection.sendNotification("react-compiler-marker/reportProgress", {

--- a/packages/vscode-client/CHANGELOG.md
+++ b/packages/vscode-client/CHANGELOG.md
@@ -4,13 +4,10 @@ All notable changes to the React Compiler Marker VS Code/Cursor plugin will be d
 
 ## [Unreleased]
 ### Added
-- **Reports sidebar**: Dedicated activity bar tab with reports list and a welcome view for generating reports
-- **"Fix with AI" button in report webview**: Generates a markdown file listing all failed components with their error locations and reasons, including AI instructions for fixing them
-- **Native theme integration**: Report webview uses VS Code theme colors for a seamless look
+- **Respect .gitignore**: New `respectGitignore` setting to honor .gitignore rules when scanning files for report generation (enabled by default)
 
 ### Changed
-- **Normalized report data**: Report webview now receives pre-processed entries instead of raw compiler events, eliminating duplicated parsing logic in the webview
-- **Improved component name display**: Entries without a function name no longer show "anonymous" — only the reason and location are shown
+- 
 
 ---
 

--- a/packages/vscode-client/README.md
+++ b/packages/vscode-client/README.md
@@ -19,6 +19,7 @@ Highlights components optimized by the React Compiler with visual indicators dir
 | `reactCompilerMarker.babelPluginPath` | `node_modules/babel-plugin-react-compiler` | Path to babel-plugin-react-compiler in your project |
 | `reactCompilerMarker.successEmoji` | `✨` | Marker for successfully optimized components |
 | `reactCompilerMarker.errorEmoji` | `🚫` | Marker for components that failed to compile |
+| `reactCompilerMarker.respectGitignore` | `true` | Respect .gitignore rules when scanning files for report generation |
 | `reactCompilerMarker.excludedDirectories` | `["node_modules", ".git", "dist", "build", "out", "coverage", ".next", ".turbo"]` | Directories to exclude when generating reports |
 | `reactCompilerMarker.supportedExtensions` | `[".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"]` | File extensions to include when generating reports |
 

--- a/packages/vscode-client/package.json
+++ b/packages/vscode-client/package.json
@@ -145,6 +145,11 @@
           "default": "node_modules/babel-plugin-react-compiler",
           "description": "Path to the babel-plugin-react-compiler in your project. By default it's 'node_modules/babel-plugin-react-compiler'"
         },
+        "reactCompilerMarker.respectGitignore": {
+          "type": "boolean",
+          "default": true,
+          "description": "Respect .gitignore rules when scanning files for report generation"
+        },
         "reactCompilerMarker.excludedDirectories": {
           "type": "array",
           "items": {

--- a/packages/vscode-client/src/extension.ts
+++ b/packages/vscode-client/src/extension.ts
@@ -387,6 +387,7 @@ function registerCommands(
                     reportId,
                     excludeDirs: config.get<string[]>("excludedDirectories"),
                     includeExtensions: config.get<string[]>("supportedExtensions"),
+                    respectGitignore: config.get<boolean>("respectGitignore"),
                   },
                 ],
               })) as { success: boolean; report?: ReactCompilerReport; error?: string };


### PR DESCRIPTION
## Summary
- Adds a new `respectGitignore` setting (enabled by default) that honors .gitignore rules when scanning files for report generation
- Integrates the `ignore` npm package in the LSP server to parse and apply .gitignore patterns (including nested .gitignore files)
- Adds the setting UI and wiring in both VS Code and IntelliJ/WebStorm clients
- Updates READMEs and changelogs for both clients
