### PR TITLE
fix(server): correctly resolve workspace folder URI on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 | IDE  | Installation |
 |------|--------------|
-| VS Code / Cursor | [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=blazejkustra.react-compiler-marker) \| [Open VSX](https://open-vsx.org/extension/blazejkustra/react-compiler-marker) |
+| VS Code / Cursor / Antigravity | [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=blazejkustra.react-compiler-marker) \| [Open VSX](https://open-vsx.org/extension/blazejkustra/react-compiler-marker) |
 | WebStorm / IntelliJ IDEA | [IntelliJ marketplace](https://plugins.jetbrains.com/plugin/29540-react-compiler-marker) |
 | Neovim | [Setup instructions](packages/nvim-client/README.md) |
 | Zed (alpha) | [Setup instructions](packages/zed-client/README.md) |
@@ -68,7 +68,7 @@ npx react-compiler-marker --format json . > report.json
 
 See the [CLI README](packages/cli/README.md) for all options.
 
-### VS Code / Cursor
+### VS Code / Cursor / Antigravity
 
 1. Install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=blazejkustra.react-compiler-marker) or search "React Compiler Marker" in Extensions
 3. Open a React component file - markers appear automatically

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,6 +13,7 @@ import {
 } from "vscode-languageserver/node";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
+import { fileURLToPath } from "node:url";
 import {
   checkReactCompiler,
   getCompiledOutput,
@@ -78,9 +79,11 @@ function logError(error: string): void {
 }
 
 connection.onInitialize((params: InitializeParams): InitializeResult => {
-  workspaceFolder = params.workspaceFolders?.[0]?.uri;
-  if (workspaceFolder?.startsWith("file://")) {
-    workspaceFolder = workspaceFolder.slice(7);
+  const workspaceFolderUri = params.workspaceFolders?.[0]?.uri;
+  if (workspaceFolderUri?.startsWith("file://")) {
+    workspaceFolder = fileURLToPath(workspaceFolderUri);
+  } else {
+    workspaceFolder = workspaceFolderUri;
   }
 
   // Store client name for feature detection


### PR DESCRIPTION
## Summary
- Use Node's `fileURLToPath` to convert the LSP workspace folder URI to a filesystem path, replacing the manual `slice(7)` that left URL-encoded characters in place and kept the leading slash on Windows drive paths.
- Fixes #68 — on Windows, `file:///c%3A/repos/...` was being turned into `/c%3A/repos/...`, so `path.join(workspaceFolder, "node_modules/babel-plugin-react-compiler")` produced `\c%3A\repos\...\node_modules\babel-plugin-react-compiler` and the require failed.
- macOS/Linux behavior is unchanged for plain paths, and now correctly handles paths containing encoded characters (e.g. spaces).

## Test plan
- [ ] Verify on Windows that the babel plugin loads and inlay hints appear (couldn't test locally — no Windows machine).
- [x] macOS: extension still activates, plugin loads, hints work.
- [x] `tsc --noEmit` passes in `packages/server`.