### PR TITLE
feat: configurable compilationMode (#67)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+ (required by `@vscode/test-electron` v3, used by the VS Code test suite)
 - npm 9+
 - JDK 21 (for IntelliJ plugin development)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,5 +31,6 @@ Overview of features supported by each editor client.
 | Error Emoji | ✅ | ✅ | ✅ | ✅ |
 | Skipped Emoji (`"use no memo"`) | ✅ | ✅ | ✅ | ✅ |
 | Babel Plugin Path | ✅ | ✅ | ✅ | ✅ |
+| Compilation Mode | ✅ | ✅ | ✅ | ✅ |
 | Excluded Directories | ✅ | ✅ | ❌ | ❌ |
 | Supported Extensions | ✅ | ✅ | ❌ | ❌ |

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Generate reports for a full-project compilation snapshot
 - Commands to activate/deactivate markers or check individual files
 - Configurable babel plugin path for custom setups
+- Configurable [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) (`infer`, `annotation`, `syntax`, `all`) to match your project's React Compiler setup
 
 ## Supported IDEs
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2172,9 +2172,9 @@
       }
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2185,7 +2185,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -8140,7 +8140,7 @@
         "@types/node": "20.x",
         "@types/vscode": "^1.95.0",
         "@vscode/test-cli": "^0.0.10",
-        "@vscode/test-electron": "^2.4.1",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/vsce": "^3.2.1",
         "esbuild": "^0.24.0",
         "npm-run-all2": "^8.0.4"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to the React Compiler Marker CLI will be documented in this 
 
 ## [Unreleased]
 ### Added
--
+- `"use no memo"` opt-outs are now counted and reported as skipped (⏭️) instead of being dropped
+- `--compilation-mode <mode>` flag to set the React Compiler `compilationMode` (`infer`, `annotation`, `syntax`, `all`; default `infer`)
 
 ### Changed
 -

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,6 +38,7 @@ npx react-compiler-marker --include-extensions .tsx,.ts --exclude-dirs node_modu
 | `--exclude-dirs <dirs>` | Comma-separated directories to exclude | `node_modules,.git,dist,build,out,coverage,.next,.turbo` |
 | `--include-extensions <exts>` | Comma-separated file extensions to include | `.js,.jsx,.ts,.tsx,.mjs,.cjs` |
 | `--babel-plugin-path <path>` | Path to babel-plugin-react-compiler | Auto-detected from `node_modules` |
+| `--compilation-mode <mode>` | React Compiler [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode): `infer`, `annotation`, `syntax`, or `all` | `infer` |
 | `--help` | Show help message | |
 | `--version` | Show version number | |
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -40,6 +40,7 @@ Options:
   --exclude-dirs <dirs>        Comma-separated directories to exclude
   --include-extensions <exts>  Comma-separated file extensions to include
   --babel-plugin-path <path>   Path to babel-plugin-react-compiler
+  --compilation-mode <mode>    React Compiler compilationMode: infer, annotation, syntax, all (default: infer)
   --help                       Show this help message
   --version                    Show version number
 `.trim();
@@ -118,6 +119,7 @@ async function main(): Promise<void> {
       "exclude-dirs": { type: "string" },
       "include-extensions": { type: "string" },
       "babel-plugin-path": { type: "string" },
+      "compilation-mode": { type: "string" },
       help: { type: "boolean", default: false },
       version: { type: "boolean", default: false },
     },
@@ -146,12 +148,24 @@ async function main(): Promise<void> {
     ?.split(",")
     .map((s) => (s.trim().startsWith(".") ? s.trim() : `.${s.trim()}`));
 
+  const compilationModeArg = values["compilation-mode"];
+  const validModes = ["infer", "annotation", "syntax", "all"] as const;
+  type Mode = (typeof validModes)[number];
+  if (compilationModeArg && !validModes.includes(compilationModeArg as Mode)) {
+    process.stderr.write(
+      `Error: Unknown compilation-mode "${compilationModeArg}". Use ${validModes.join(", ")}.\n`
+    );
+    process.exit(1);
+  }
+  const compilationMode = (compilationModeArg as Mode | undefined) ?? "infer";
+
   process.stderr.write(`Scanning ${root}...\n`);
 
   const startTime = performance.now();
   const report = await generateReport({
     root,
     babelPluginPath,
+    compilationMode,
     excludeDirs,
     includeExtensions,
     onProgress({ processed, total }) {

--- a/packages/intellij-client/CHANGELOG.md
+++ b/packages/intellij-client/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to the React Compiler Marker WebStorm/IntelliJ plugin will b
 
 ## [Unreleased]
 ### Added
+- **`"use no memo"` opt-outs**: Functions opted out of the compiler are now reported as skipped (configurable Skipped Emoji, default ⏭️) instead of being dropped from markers and reports
 - **Respect .gitignore**: New setting to honor .gitignore rules when scanning files for report generation (enabled by default)
+- **Compilation Mode**: New setting to choose the React Compiler `compilationMode` (`infer`, `annotation`, `syntax`, `all`) so markers match your project's configuration
 
 ---
 

--- a/packages/intellij-client/README.md
+++ b/packages/intellij-client/README.md
@@ -64,7 +64,9 @@ Go to **Settings/Preferences** → **Languages & Frameworks** → **React Compil
 
 - **Success Emoji**: Emoji shown for optimized components (default: ✨)
 - **Error Emoji**: Emoji shown for failed components (default: 🚫)
+- **Skipped Emoji**: Emoji shown for components opted out via `"use no memo"` (default: ⏭️)
 - **Babel Plugin Path**: Path to babel-plugin-react-compiler (default: `node_modules/babel-plugin-react-compiler`)
+- **Compilation Mode**: React Compiler [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) — `infer`, `annotation`, `syntax`, or `all` (default: `infer`)
 - **Respect .gitignore**: Honor .gitignore rules when scanning files for report generation (default: enabled)
 
 ## How It Works

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/actions/GenerateReportAction.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/actions/GenerateReportAction.kt
@@ -50,6 +50,7 @@ class GenerateReportAction : AnAction() {
             "excludeDirs" to settings.excludedDirectoriesList,
             "includeExtensions" to settings.supportedExtensionsList,
             "respectGitignore" to settings.respectGitignore,
+            "compilationMode" to settings.compilationMode,
             "emojis" to mapOf(
                 "success" to settings.successEmoji,
                 "error" to settings.errorEmoji,

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerConfigurable.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerConfigurable.kt
@@ -7,6 +7,7 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
+import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JPanel
 
@@ -20,6 +21,9 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
     private var excludedDirectoriesField: JBTextField? = null
     private var supportedExtensionsField: JBTextField? = null
     private var respectGitignoreCheckbox: JBCheckBox? = null
+    private var compilationModeComboBox: JComboBox<String>? = null
+
+    private val compilationModeOptions = arrayOf("infer", "annotation", "syntax", "all")
 
     override fun getDisplayName(): String = "React Compiler Marker"
 
@@ -32,6 +36,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         excludedDirectoriesField = JBTextField()
         supportedExtensionsField = JBTextField()
         respectGitignoreCheckbox = JBCheckBox("Respect .gitignore rules when scanning")
+        compilationModeComboBox = JComboBox(compilationModeOptions)
 
         return FormBuilder.createFormBuilder()
             .addComponent(enabledCheckbox!!)
@@ -41,6 +46,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
             .addLabeledComponent(JBLabel("Skipped emoji:"), skippedEmojiField!!, 1, false)
             .addSeparator()
             .addLabeledComponent(JBLabel("Babel plugin path:"), babelPluginPathField!!, 1, false)
+            .addLabeledComponent(JBLabel("Compilation mode:"), compilationModeComboBox!!, 1, false)
             .addSeparator()
             .addLabeledComponent(JBLabel("Excluded directories (comma-separated):"), excludedDirectoriesField!!, 1, false)
             .addLabeledComponent(JBLabel("Supported extensions (comma-separated):"), supportedExtensionsField!!, 1, false)
@@ -59,7 +65,8 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
                babelPluginPathField?.text != settings.babelPluginPath ||
                excludedDirectoriesField?.text != settings.excludedDirectories ||
                supportedExtensionsField?.text != settings.supportedExtensions ||
-               respectGitignoreCheckbox?.isSelected != settings.respectGitignore
+               respectGitignoreCheckbox?.isSelected != settings.respectGitignore ||
+               compilationModeComboBox?.selectedItem != settings.compilationMode
     }
 
     override fun apply() {
@@ -72,6 +79,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         settings.excludedDirectories = excludedDirectoriesField?.text ?: ""
         settings.supportedExtensions = supportedExtensionsField?.text ?: ""
         settings.respectGitignore = respectGitignoreCheckbox?.isSelected ?: true
+        settings.compilationMode = (compilationModeComboBox?.selectedItem as? String) ?: "infer"
 
         // Update LSP server configuration
         val lspManager = ReactCompilerLspServerManager.getInstance(project)
@@ -88,6 +96,7 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         excludedDirectoriesField?.text = settings.excludedDirectories
         supportedExtensionsField?.text = settings.supportedExtensions
         respectGitignoreCheckbox?.isSelected = settings.respectGitignore
+        compilationModeComboBox?.selectedItem = settings.compilationMode
     }
 
     override fun disposeUIResources() {
@@ -99,5 +108,6 @@ class ReactCompilerMarkerConfigurable(private val project: Project) : Configurab
         excludedDirectoriesField = null
         supportedExtensionsField = null
         respectGitignoreCheckbox = null
+        compilationModeComboBox = null
     }
 }

--- a/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerSettings.kt
+++ b/packages/intellij-client/src/main/kotlin/com/blazejkustra/reactcompilermarker/settings/ReactCompilerMarkerSettings.kt
@@ -22,6 +22,7 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
         var excludedDirectories: String = "node_modules, .git, dist, build, out, coverage, .next, .turbo"
         var supportedExtensions: String = ".js, .jsx, .ts, .tsx, .mjs, .cjs"
         var respectGitignore: Boolean = true
+        var compilationMode: String = "infer"
     }
 
     override fun getState(): State = myState
@@ -78,6 +79,12 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
             myState.respectGitignore = value
         }
 
+    var compilationMode: String
+        get() = myState.compilationMode
+        set(value) {
+            myState.compilationMode = value
+        }
+
     val excludedDirectoriesList: List<String>
         get() = excludedDirectories.split(",").map { it.trim() }.filter { it.isNotEmpty() }
 
@@ -91,7 +98,8 @@ class ReactCompilerMarkerSettings : PersistentStateComponent<ReactCompilerMarker
         "babelPluginPath" to babelPluginPath,
         "excludedDirectories" to excludedDirectoriesList,
         "supportedExtensions" to supportedExtensionsList,
-        "respectGitignore" to respectGitignore
+        "respectGitignore" to respectGitignore,
+        "compilationMode" to compilationMode
     )
 
     companion object {

--- a/packages/nvim-client/README.md
+++ b/packages/nvim-client/README.md
@@ -53,7 +53,15 @@ require('react-compiler-marker').setup({
   emojis = {
     success = "✨",  -- Successfully optimized
     error = "🚫",    -- Failed to optimize
+    skipped = "⏭️",  -- Opted out via "use no memo"
   },
+
+  -- React Compiler `compilationMode`: "infer" | "annotation" | "syntax" | "all"
+  -- See https://react.dev/reference/react-compiler/compilationMode
+  compilation_mode = "infer",
+
+  -- Path to babel-plugin-react-compiler (relative to workspace root)
+  babel_plugin_path = "node_modules/babel-plugin-react-compiler",
 
   -- Inlay hint settings
   inlay_hints = {

--- a/packages/nvim-client/lua/react-compiler-marker/config.lua
+++ b/packages/nvim-client/lua/react-compiler-marker/config.lua
@@ -25,6 +25,10 @@ M.defaults = {
   -- Path to babel-plugin-react-compiler (relative to workspace root)
   babel_plugin_path = "node_modules/babel-plugin-react-compiler",
 
+  -- React Compiler `compilationMode` ("infer" | "annotation" | "syntax" | "all")
+  -- See https://react.dev/reference/react-compiler/compilationMode
+  compilation_mode = "infer",
+
   -- Enable/disable on startup
   enabled = true,
 
@@ -126,6 +130,7 @@ function M.get_server_settings()
       errorEmoji = M.config.emojis.error,
       skippedEmoji = M.config.emojis.skipped,
       babelPluginPath = M.config.babel_plugin_path,
+      compilationMode = M.config.compilation_mode,
     },
   }
 end

--- a/packages/server/src/cache.ts
+++ b/packages/server/src/cache.ts
@@ -12,13 +12,13 @@ export class LRUCache<T> {
     this.maxSize = maxSize;
   }
 
-  private generateKey(content: string, filename: string): string {
+  private generateKey(content: string, filename: string, mode: string): string {
     const hash = crypto.createHash("md5").update(content).digest("hex");
-    return `${filename}:${hash}`;
+    return `${filename}:${mode}:${hash}`;
   }
 
-  get(content: string, filename: string): T | undefined {
-    const key = this.generateKey(content, filename);
+  get(content: string, filename: string, mode: string): T | undefined {
+    const key = this.generateKey(content, filename, mode);
     const entry = this.cache.get(key);
 
     if (!entry) {
@@ -32,8 +32,8 @@ export class LRUCache<T> {
     return entry.result;
   }
 
-  set(content: string, filename: string, result: T): void {
-    const key = this.generateKey(content, filename);
+  set(content: string, filename: string, mode: string, result: T): void {
+    const key = this.generateKey(content, filename, mode);
 
     // Remove oldest entries if at capacity
     if (this.cache.size >= this.maxSize) {

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -34,9 +34,31 @@ export type LoggerEvent = {
   };
 };
 
+export type CompilationMode = "infer" | "annotation" | "syntax" | "all";
+
+export const DEFAULT_COMPILATION_MODE: CompilationMode = "infer";
+
+const VALID_COMPILATION_MODES: ReadonlySet<CompilationMode> = new Set([
+  "infer",
+  "annotation",
+  "syntax",
+  "all",
+]);
+
+export function normalizeCompilationMode(value: unknown): CompilationMode {
+  if (typeof value === "string" && VALID_COMPILATION_MODES.has(value as CompilationMode)) {
+    return value as CompilationMode;
+  }
+  if (value !== undefined && value !== null) {
+    throttledError(
+      `Invalid compilationMode "${String(value)}". Falling back to "${DEFAULT_COMPILATION_MODE}". Valid values: infer, annotation, syntax, all.`
+    );
+  }
+  return DEFAULT_COMPILATION_MODE;
+}
+
 const DEFAULT_COMPILER_OPTIONS = {
   noEmit: false,
-  compilationMode: "infer",
   panicThreshold: "none",
   environment: {
     enableTreatRefLikeIdentifiersAsRefs: true,
@@ -78,7 +100,8 @@ function runBabelPluginReactCompiler(
   BabelPluginReactCompiler: PluginObj | undefined,
   text: string,
   file: string,
-  language: "flow" | "typescript"
+  language: "flow" | "typescript",
+  compilationMode: CompilationMode
 ) {
   const successfulCompilations: Array<LoggerEvent> = [];
   const failedCompilations: Array<LoggerEvent> = [];
@@ -106,6 +129,7 @@ function runBabelPluginReactCompiler(
 
   const COMPILER_OPTIONS = {
     ...DEFAULT_COMPILER_OPTIONS,
+    compilationMode,
     logger,
     noEmit: true,
   };
@@ -177,7 +201,8 @@ export function checkReactCompiler(
   sourceCode: string,
   filename: string,
   workspaceFolder: string | undefined,
-  babelPluginPath: string
+  babelPluginPath: string,
+  compilationMode: CompilationMode = DEFAULT_COMPILATION_MODE
 ): CompilationResult {
   // Check cache first
   const cached = compilationCache.get(sourceCode, filename);
@@ -197,7 +222,8 @@ export function checkReactCompiler(
       BabelPluginReactCompiler,
       sourceCode,
       filename,
-      language
+      language,
+      compilationMode
     );
 
     // Cache the result
@@ -220,7 +246,8 @@ export async function getCompiledOutput(
   sourceCode: string,
   filename: string,
   workspaceFolder: string | undefined,
-  babelPluginPath: string
+  babelPluginPath: string,
+  compilationMode: CompilationMode = DEFAULT_COMPILATION_MODE
 ): Promise<string> {
   const BabelPluginReactCompiler = importBabelPluginReactCompiler(workspaceFolder, babelPluginPath);
 
@@ -239,7 +266,7 @@ export async function getCompiledOutput(
       filename,
       highlightCode: false,
       retainLines: true,
-      plugins: [[BabelPluginReactCompiler, DEFAULT_COMPILER_OPTIONS]],
+      plugins: [[BabelPluginReactCompiler, { ...DEFAULT_COMPILER_OPTIONS, compilationMode }]],
       sourceType: "module",
       configFile: false,
       babelrc: false,

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -202,10 +202,10 @@ export function checkReactCompiler(
   filename: string,
   workspaceFolder: string | undefined,
   babelPluginPath: string,
-  compilationMode: CompilationMode = DEFAULT_COMPILATION_MODE
+  compilationMode: CompilationMode
 ): CompilationResult {
-  // Check cache first
-  const cached = compilationCache.get(sourceCode, filename);
+  // Check cache first (keyed by content, filename and compilation mode)
+  const cached = compilationCache.get(sourceCode, filename, compilationMode);
   if (cached) {
     return cached;
   }
@@ -227,7 +227,7 @@ export function checkReactCompiler(
     );
 
     // Cache the result
-    compilationCache.set(sourceCode, filename, result);
+    compilationCache.set(sourceCode, filename, compilationMode, result);
 
     return result;
   } catch (error: any) {
@@ -237,7 +237,7 @@ export function checkReactCompiler(
       failedCompilations: [],
       skippedCompilations: [],
     };
-    compilationCache.set(sourceCode, filename, emptyResult);
+    compilationCache.set(sourceCode, filename, compilationMode, emptyResult);
     return emptyResult;
   }
 }
@@ -247,7 +247,7 @@ export async function getCompiledOutput(
   filename: string,
   workspaceFolder: string | undefined,
   babelPluginPath: string,
-  compilationMode: CompilationMode = DEFAULT_COMPILATION_MODE
+  compilationMode: CompilationMode
 ): Promise<string> {
   const BabelPluginReactCompiler = importBabelPluginReactCompiler(workspaceFolder, babelPluginPath);
 

--- a/packages/server/src/report/generate.ts
+++ b/packages/server/src/report/generate.ts
@@ -3,7 +3,12 @@ import type { Dirent } from "fs";
 import os from "os";
 import path from "path";
 import ignore, { type Ignore } from "ignore";
-import { checkReactCompiler, LoggerEvent } from "../checkReactCompiler";
+import {
+  checkReactCompiler,
+  LoggerEvent,
+  type CompilationMode,
+  DEFAULT_COMPILATION_MODE,
+} from "../checkReactCompiler";
 
 /**
  * Full report generated from scanning a project with the React Compiler.
@@ -40,6 +45,8 @@ export interface ReportOptions {
   root: string;
   /** Path to the babel-plugin-react-compiler entry. */
   babelPluginPath: string;
+  /** React Compiler `compilationMode` (default: "infer"). */
+  compilationMode?: CompilationMode;
   /** Maximum number of files processed in parallel. */
   maxConcurrency?: number;
   /** File extensions to include (e.g. [".js", ".tsx"]). */
@@ -201,6 +208,7 @@ export async function generateReport(options: ReportOptions): Promise<ReactCompi
   const excludeDirs = new Set(options.excludeDirs ?? Array.from(DEFAULT_EXCLUDES));
   const maxConcurrency = options.maxConcurrency ?? Math.max(1, os.cpus().length - 1);
   const respectGitignore = options.respectGitignore ?? true;
+  const compilationMode = options.compilationMode ?? DEFAULT_COMPILATION_MODE;
 
   const files = await listSourceFiles(root, includeExtensions, excludeDirs, respectGitignore);
   const totalFiles = files.length;
@@ -224,7 +232,7 @@ export async function generateReport(options: ReportOptions): Promise<ReactCompi
     try {
       const sourceCode = await fs.readFile(filePath, "utf8");
       const { successfulCompilations, failedCompilations, skippedCompilations } =
-        checkReactCompiler(sourceCode, filePath, root, options.babelPluginPath);
+        checkReactCompiler(sourceCode, filePath, root, options.babelPluginPath, compilationMode);
       return {
         path: path.relative(root, filePath),
         success: successfulCompilations,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -19,6 +19,9 @@ import {
   getCompiledOutput,
   clearPluginCache,
   clearCompilationCache,
+  normalizeCompilationMode,
+  DEFAULT_COMPILATION_MODE,
+  type CompilationMode,
 } from "./checkReactCompiler";
 import { generateInlayHints } from "./inlayHints";
 import { debounce } from "./debounce";
@@ -48,6 +51,7 @@ interface Settings {
   errorEmoji: string | null;
   skippedEmoji: string | null;
   babelPluginPath: string;
+  compilationMode: CompilationMode;
 }
 
 let globalSettings: Settings = {
@@ -55,6 +59,7 @@ let globalSettings: Settings = {
   errorEmoji: "🚫",
   skippedEmoji: "⏭️",
   babelPluginPath: "node_modules/babel-plugin-react-compiler",
+  compilationMode: DEFAULT_COMPILATION_MODE,
 };
 
 // Tooltip format preference from client (markdown or html)
@@ -135,16 +140,23 @@ connection.onDidChangeConfiguration((change) => {
   const settings = change.settings?.reactCompilerMarker;
   if (settings) {
     const oldBabelPluginPath = globalSettings.babelPluginPath;
+    const oldCompilationMode = globalSettings.compilationMode;
     globalSettings = {
       successEmoji: settings.successEmoji ?? "✨",
       errorEmoji: settings.errorEmoji ?? "🚫",
       skippedEmoji: settings.skippedEmoji ?? "⏭️",
       babelPluginPath: settings.babelPluginPath ?? "node_modules/babel-plugin-react-compiler",
+      compilationMode: normalizeCompilationMode(settings.compilationMode),
     };
 
     // Clear caches if babel plugin path changed
     if (oldBabelPluginPath !== globalSettings.babelPluginPath) {
       clearPluginCache();
+      clearCompilationCache();
+    }
+
+    // Compilation cache is keyed by source+filename only — invalidate on mode change
+    if (oldCompilationMode !== globalSettings.compilationMode) {
       clearCompilationCache();
     }
   }
@@ -183,7 +195,8 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
           sourceCode,
           fileNameForCompiler,
           workspaceFolder,
-          globalSettings.babelPluginPath
+          globalSettings.babelPluginPath,
+          globalSettings.compilationMode
         );
 
       return generateInlayHints(
@@ -234,7 +247,8 @@ connection.onHover((params: HoverParams): Hover | null => {
         sourceCode,
         fileNameForCompiler,
         workspaceFolder,
-        globalSettings.babelPluginPath
+        globalSettings.babelPluginPath,
+        globalSettings.compilationMode
       );
 
     // Generate hints to find which components have hints on which lines
@@ -298,7 +312,8 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
           document.getText(),
           fileUri,
           workspaceFolder,
-          globalSettings.babelPluginPath
+          globalSettings.babelPluginPath,
+          globalSettings.compilationMode
         );
         return { success: true, code: compiled };
       } catch (error: any) {
@@ -325,6 +340,9 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
         const report = await generateReport({
           root: reportRoot,
           babelPluginPath: globalSettings.babelPluginPath,
+          compilationMode: normalizeCompilationMode(
+            options?.compilationMode ?? globalSettings.compilationMode
+          ),
           maxConcurrency: options?.maxConcurrency,
           includeExtensions: options?.includeExtensions,
           excludeDirs: options?.excludeDirs,
@@ -360,6 +378,9 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
         const report = await generateReport({
           root: htmlReportRoot,
           babelPluginPath: globalSettings.babelPluginPath,
+          compilationMode: normalizeCompilationMode(
+            htmlOptions?.compilationMode ?? globalSettings.compilationMode
+          ),
           maxConcurrency: htmlOptions?.maxConcurrency,
           includeExtensions: htmlOptions?.includeExtensions,
           excludeDirs: htmlOptions?.excludeDirs,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -140,7 +140,6 @@ connection.onDidChangeConfiguration((change) => {
   const settings = change.settings?.reactCompilerMarker;
   if (settings) {
     const oldBabelPluginPath = globalSettings.babelPluginPath;
-    const oldCompilationMode = globalSettings.compilationMode;
     globalSettings = {
       successEmoji: settings.successEmoji ?? "✨",
       errorEmoji: settings.errorEmoji ?? "🚫",
@@ -152,11 +151,6 @@ connection.onDidChangeConfiguration((change) => {
     // Clear caches if babel plugin path changed
     if (oldBabelPluginPath !== globalSettings.babelPluginPath) {
       clearPluginCache();
-      clearCompilationCache();
-    }
-
-    // Compilation cache is keyed by source+filename only — invalidate on mode change
-    if (oldCompilationMode !== globalSettings.compilationMode) {
       clearCompilationCache();
     }
   }

--- a/packages/vscode-client/.vscode-test.mjs
+++ b/packages/vscode-client/.vscode-test.mjs
@@ -1,5 +1,14 @@
 import { defineConfig } from '@vscode/test-cli';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Keep the user-data dir out of the workspace. VS Code opens a Unix domain
+// socket inside it, and macOS caps those paths at 103 chars — the default
+// (<workspace>/.vscode-test/user-data) overflows on CI runners, which fail
+// with `listen EINVAL: invalid argument .../1.13-main.sock`.
+const userDataDir = path.join(os.tmpdir(), 'rcm-vscode-test');
 
 export default defineConfig({
 	files: 'out/test/**/*.test.js',
+	launchArgs: [`--user-data-dir=${userDataDir}`],
 });

--- a/packages/vscode-client/CHANGELOG.md
+++ b/packages/vscode-client/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the React Compiler Marker VS Code/Cursor plugin will be d
 
 ## [Unreleased]
 ### Added
+- **`"use no memo"` opt-outs**: Functions opted out of the compiler are now reported as skipped (`reactCompilerMarker.skippedEmoji`, default ⏭️) instead of being dropped from markers and reports
 - **Compilation Mode**: New `reactCompilerMarker.compilationMode` setting (`infer`, `annotation`, `syntax`, `all`) to match your project's React Compiler configuration. Invalid values fall back to `infer` with a warning. Available in all clients and via the CLI's `--compilation-mode` flag.
 
 ### Changed

--- a/packages/vscode-client/CHANGELOG.md
+++ b/packages/vscode-client/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the React Compiler Marker VS Code/Cursor plugin will be d
 
 ## [Unreleased]
 ### Added
--
+- **Compilation Mode**: New `reactCompilerMarker.compilationMode` setting (`infer`, `annotation`, `syntax`, `all`) to match your project's React Compiler configuration. Invalid values fall back to `infer` with a warning. Available in all clients and via the CLI's `--compilation-mode` flag.
 
 ### Changed
 - 

--- a/packages/vscode-client/README.md
+++ b/packages/vscode-client/README.md
@@ -19,6 +19,8 @@ Highlights components optimized by the React Compiler with visual indicators dir
 | `reactCompilerMarker.babelPluginPath` | `node_modules/babel-plugin-react-compiler` | Path to babel-plugin-react-compiler in your project |
 | `reactCompilerMarker.successEmoji` | `✨` | Marker for successfully optimized components |
 | `reactCompilerMarker.errorEmoji` | `🚫` | Marker for components that failed to compile |
+| `reactCompilerMarker.skippedEmoji` | `⏭️` | Marker for components opted out via `"use no memo"` |
+| `reactCompilerMarker.compilationMode` | `infer` | React Compiler [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode): `infer`, `annotation`, `syntax`, or `all` |
 | `reactCompilerMarker.respectGitignore` | `true` | Respect .gitignore rules when scanning files for report generation |
 | `reactCompilerMarker.excludedDirectories` | `["node_modules", ".git", "dist", "build", "out", "coverage", ".next", ".turbo"]` | Directories to exclude when generating reports |
 | `reactCompilerMarker.supportedExtensions` | `[".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"]` | File extensions to include when generating reports |

--- a/packages/vscode-client/package.json
+++ b/packages/vscode-client/package.json
@@ -199,6 +199,17 @@
           "nullable": true,
           "default": "⏭️",
           "description": "Emoji marker to display next to components that opted out via the \"use no memo\" directive"
+        },
+        "reactCompilerMarker.compilationMode": {
+          "type": "string",
+          "enum": [
+            "infer",
+            "annotation",
+            "syntax",
+            "all"
+          ],
+          "default": "infer",
+          "markdownDescription": "Controls which functions React Compiler attempts to compile. Match this to your project's babel-plugin-react-compiler configuration. See [compilationMode docs](https://react.dev/reference/react-compiler/compilationMode)."
         }
       }
     }

--- a/packages/vscode-client/package.json
+++ b/packages/vscode-client/package.json
@@ -238,7 +238,7 @@
     "@types/vscode": "^1.95.0",
     "@types/node": "20.x",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/vsce": "^3.2.1",
     "esbuild": "^0.24.0",
     "npm-run-all2": "^8.0.4"

--- a/packages/vscode-client/test/decorations.test.ts
+++ b/packages/vscode-client/test/decorations.test.ts
@@ -22,12 +22,13 @@ function readFixture(name: string): string {
 }
 
 // Helper to call checkReactCompiler with test defaults
-function compileFixture(text: string, filename: string) {
+function compileFixture(text: string, filename: string, compilationMode?: string) {
   return checkReactCompiler(
     text,
     filename,
     undefined, // workspaceFolder
-    "node_modules/babel-plugin-react-compiler" // babelPluginPath
+    "node_modules/babel-plugin-react-compiler", // babelPluginPath
+    compilationMode
   );
 }
 
@@ -163,6 +164,31 @@ suite("Critical error handling", () => {
         `Failure at line ${failStart} overlaps the opted-out component (lines ${skipStart}-${skipEnd}); opt-outs must not be reported as failures.`
       );
     }
+  });
+
+  test('annotation-mode.tsx: only "use memo" components compile under compilationMode: "annotation"', () => {
+    const text = readFixture("annotation-mode.tsx").trim();
+    const filename = "/mock/annotation-mode.tsx";
+
+    const inferred = compileFixture(text, filename, "infer");
+    assert.strictEqual(
+      inferred.successfulCompilations.length,
+      2,
+      `Expected 2 compiled components under "infer", got ${inferred.successfulCompilations.length}`
+    );
+
+    // Cache is keyed by source+filename; vary filename so we get a fresh run for "annotation".
+    const annotated = compileFixture(text, "/mock/annotation-mode-annotation.tsx", "annotation");
+    assert.strictEqual(
+      annotated.successfulCompilations.length,
+      1,
+      `Expected only the "use memo" component to compile under "annotation", got ${annotated.successfulCompilations.length}`
+    );
+    const compiled = annotated.successfulCompilations[0];
+    assert.ok(
+      compiled.fnName?.includes("OptedIn") || /OptedInComponent/.test(JSON.stringify(compiled)),
+      `Expected OptedInComponent to be the compiled function, got ${compiled.fnName}`
+    );
   });
 
   test("error-without-ranges.tsx: handles errors without location ranges gracefully", () => {

--- a/packages/vscode-client/test/decorations.test.ts
+++ b/packages/vscode-client/test/decorations.test.ts
@@ -22,7 +22,7 @@ function readFixture(name: string): string {
 }
 
 // Helper to call checkReactCompiler with test defaults
-function compileFixture(text: string, filename: string, compilationMode?: string) {
+function compileFixture(text: string, filename: string, compilationMode: string = "infer") {
   return checkReactCompiler(
     text,
     filename,
@@ -177,8 +177,9 @@ suite("Critical error handling", () => {
       `Expected 2 compiled components under "infer", got ${inferred.successfulCompilations.length}`
     );
 
-    // Cache is keyed by source+filename; vary filename so we get a fresh run for "annotation".
-    const annotated = compileFixture(text, "/mock/annotation-mode-annotation.tsx", "annotation");
+    // Same content and filename as above: the compilation cache must key on the mode too,
+    // otherwise this reads back the "infer" result.
+    const annotated = compileFixture(text, filename, "annotation");
     assert.strictEqual(
       annotated.successfulCompilations.length,
       1,
@@ -188,6 +189,33 @@ suite("Critical error handling", () => {
     assert.ok(
       compiled.fnName?.includes("OptedIn") || /OptedInComponent/.test(JSON.stringify(compiled)),
       `Expected OptedInComponent to be the compiled function, got ${compiled.fnName}`
+    );
+  });
+
+  test("compilation cache is keyed by compilation mode, not just source and filename", () => {
+    const text = readFixture("annotation-mode.tsx").trim();
+    const filename = "/mock/annotation-mode-cache.tsx";
+
+    // Populate the cache under "annotation" first, then read the same file back under
+    // "infer" and vice versa: neither mode may serve the other's cached result.
+    const annotated = compileFixture(text, filename, "annotation");
+    const inferred = compileFixture(text, filename, "infer");
+    const annotatedAgain = compileFixture(text, filename, "annotation");
+
+    assert.strictEqual(
+      annotated.successfulCompilations.length,
+      1,
+      `Expected 1 compiled component under "annotation", got ${annotated.successfulCompilations.length}`
+    );
+    assert.strictEqual(
+      inferred.successfulCompilations.length,
+      2,
+      `Expected 2 compiled components under "infer", got ${inferred.successfulCompilations.length}`
+    );
+    assert.strictEqual(
+      annotatedAgain.successfulCompilations.length,
+      1,
+      `Expected the cached "annotation" entry to survive an "infer" run, got ${annotatedAgain.successfulCompilations.length}`
     );
   });
 

--- a/packages/vscode-client/test/fixtures/annotation-mode.tsx
+++ b/packages/vscode-client/test/fixtures/annotation-mode.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+// Opted in via "use memo" — should compile under compilationMode: "annotation".
+export function OptedInComponent({ name }: { name: string }) {
+  "use memo";
+
+  return <div>Hello {name}</div>;
+}
+
+// Plain component without an opt-in directive — under "annotation" the compiler
+// should leave this alone, but under "infer" it would still be compiled.
+export function PlainComponent({ name }: { name: string }) {
+  return <div>Hi {name}</div>;
+}

--- a/packages/zed-client/README.md
+++ b/packages/zed-client/README.md
@@ -55,7 +55,8 @@ Add settings to your Zed `settings.json` (`cmd+,`):
         "successEmoji": "✨",
         "errorEmoji": "🚫",
         "skippedEmoji": "⏭️",
-        "babelPluginPath": "node_modules/babel-plugin-react-compiler"
+        "babelPluginPath": "node_modules/babel-plugin-react-compiler",
+        "compilationMode": "infer"
       }
     }
   }
@@ -70,6 +71,7 @@ Add settings to your Zed `settings.json` (`cmd+,`):
 | `errorEmoji` | `🚫` | Emoji shown for components with optimization errors |
 | `skippedEmoji` | `⏭️` | Emoji shown for components that opted out via `"use no memo"` |
 | `babelPluginPath` | `node_modules/babel-plugin-react-compiler` | Path to the babel-plugin-react-compiler package |
+| `compilationMode` | `infer` | React Compiler [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode): `infer`, `annotation`, `syntax`, or `all` |
 
 ## Limitations
 


### PR DESCRIPTION
Closes #67.

## Summary
- Expose React Compiler's [`compilationMode`](https://react.dev/reference/react-compiler/compilationMode) as a per-workspace setting (`infer` | `annotation` | `syntax` | `all`, default `infer`) instead of hardcoding `"infer"` in `checkReactCompiler.ts`.
- Plumb the setting through all four clients (VS Code, IntelliJ, Neovim, Zed) plus the CLI (`--compilation-mode`).
- Invalid values fall back to `"infer"` with a throttled error, so a typo can't break the inlay-hint pass.
- Compilation cache is invalidated when the mode changes (cache is keyed only by source+filename, so a flip would otherwise serve stale results).
- Other compiler internals (`panicThreshold`, `enableTreatRefLikeIdentifiersAsRefs`) stay hardcoded — they're set the way they are *because* this is a marker tool.

## Why this matters
Teams using `compilationMode: "annotation"` for incremental adoption (only `"use memo"` opted-in functions get compiled) currently see the extension light up every component, which doesn't match what React Compiler actually does in their app. With this setting, the markers track the real build.

> Note: base is `feat/use-no-memo-skipped-bucket` because that branch contains the `"use no memo"` skipped-bucket work (#73) this PR builds on top of.

## Test plan
- [x] `npm test` in `packages/vscode-client` — 14/14 pass, including a new `annotation-mode.tsx` fixture asserting that under `"annotation"` only the `"use memo"` component compiles, while `"infer"` still compiles both.
- [x] `tsc -b` clean across `server` and `vscode-client`; ESLint clean.
- [x] CLI `--compilation-mode` flag rejects invalid values before invoking the report.
- [ ] Manual smoke test in VS Code with `reactCompilerMarker.compilationMode` flipped between values; confirm cache invalidates and markers update.
- [ ] Manual sanity check that IntelliJ/Neovim/Zed clients still load (Kotlin/Lua not built in CI here).