### PR TITLE
chore: add dependabot to watch babel-plugin-react-compiler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # babel-plugin-react-compiler is pinned exactly (not a range) because the
+  # server depends on its logger option and event shapes, so a bump needs a
+  # look rather than a silent range resolution. Scoped to that one package to
+  # keep the PR volume useful.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    allow:
+      - dependency-name: babel-plugin-react-compiler
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
`packages/server` pins `babel-plugin-react-compiler` exactly (`1.0.0`, no caret), so nothing tells us when a new version ships. Today's `latest` is still `1.0.0` (published 2025-10-07), but that won't hold forever.

Adds a Dependabot config that opens a PR when it moves.

Scoped with `allow` to that one package on purpose — unscoped, this would open PRs for every dependency across all four workspaces, which is how Dependabot ends up ignored. Easy to widen later.

`directory: /` because the lockfile is at the root; Dependabot resolves the npm workspaces from there.

Not included: a watcher for `babel-plugin-react-compiler-rust` (the Rust port). It's in `facebook/react` under `compiler/crates` but is not published to npm, and their own `crates/TODO.md` still shows e2e parity gaps (Babel 1792/1802). Dependabot can't watch a package we don't depend on, and a cron job for it would re-fire weekly forever once it fires — not worth it yet.