### PR TITLE
fix: resolve compiler plugin and reports per workspace root

### DIFF
--- a/packages/server/src/cache.ts
+++ b/packages/server/src/cache.ts
@@ -12,13 +12,20 @@ export class LRUCache<T> {
     this.maxSize = maxSize;
   }
 
-  private generateKey(content: string, filename: string, mode: string): string {
+  /**
+   * `scope` identifies the compiler that produced the result — the workspace
+   * root and plugin path it was loaded from. Without it the same absolute file
+   * analyzed against two different roots (nested roots, or a report scanning an
+   * outer root while inlay hints resolve the inner one) would share an entry,
+   * silently serving one root's plugin output to the other.
+   */
+  private generateKey(content: string, filename: string, mode: string, scope: string): string {
     const hash = crypto.createHash("md5").update(content).digest("hex");
-    return `${filename}:${mode}:${hash}`;
+    return `${scope}:${filename}:${mode}:${hash}`;
   }
 
-  get(content: string, filename: string, mode: string): T | undefined {
-    const key = this.generateKey(content, filename, mode);
+  get(content: string, filename: string, mode: string, scope: string): T | undefined {
+    const key = this.generateKey(content, filename, mode, scope);
     const entry = this.cache.get(key);
 
     if (!entry) {
@@ -32,8 +39,8 @@ export class LRUCache<T> {
     return entry.result;
   }
 
-  set(content: string, filename: string, mode: string, result: T): void {
-    const key = this.generateKey(content, filename, mode);
+  set(content: string, filename: string, mode: string, scope: string, result: T): void {
+    const key = this.generateKey(content, filename, mode, scope);
 
     // Remove oldest entries if at capacity
     if (this.cache.size >= this.maxSize) {

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -199,12 +199,17 @@ function importBabelPluginReactCompiler(
     }
   }
 
-  // Fallback to bundled version
-  const bundled = pluginCache.get(BUNDLED_PLUGIN_CACHE_KEY);
+  // Fallback to the bundled version. Cache it under the root's key too, so a
+  // root without a local plugin does not retry the failing require() for every
+  // file it scans.
+  const bundled = pluginCache.get(BUNDLED_PLUGIN_CACHE_KEY) ?? loadBundledPlugin();
   if (bundled) {
-    return bundled;
+    pluginCache.set(cacheKey, bundled);
   }
+  return bundled;
+}
 
+function loadBundledPlugin(): PluginObj | undefined {
   try {
     const plugin: PluginObj = require("babel-plugin-react-compiler");
     pluginCache.set(BUNDLED_PLUGIN_CACHE_KEY, plugin);

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -71,11 +71,14 @@ const DEFAULT_COMPILER_OPTIONS = {
 // top-level await).
 const HERMES_PARSER_OPTIONS = { parseLangTypes: "flow" };
 
-// Module-level cache for the Babel plugin
-let cachedPlugin: PluginObj | undefined;
+// Cache for the Babel plugin, keyed by the workspace root it was loaded from.
+// A multi-root workspace can have a different (or differently versioned)
+// babel-plugin-react-compiler per root, so a single cached plugin would make
+// every root after the first analyze its files with the wrong compiler.
+const pluginCache = new Map<string, PluginObj>();
 
 export function clearPluginCache(): void {
-  cachedPlugin = undefined;
+  pluginCache.clear();
 }
 
 // Compilation result cache (50 entries max)
@@ -168,35 +171,48 @@ function runBabelPluginReactCompiler(
   };
 }
 
+const BUNDLED_PLUGIN_CACHE_KEY = "\0bundled";
+
 function importBabelPluginReactCompiler(
   workspaceFolder: string | undefined,
   babelPluginPath: string
 ): PluginObj | undefined {
-  // Return cached plugin if available
-  if (cachedPlugin) {
-    return cachedPlugin;
+  const cacheKey = workspaceFolder
+    ? `${workspaceFolder}\0${babelPluginPath}`
+    : BUNDLED_PLUGIN_CACHE_KEY;
+
+  // Return the plugin cached for this workspace root, if any
+  const cached = pluginCache.get(cacheKey);
+  if (cached) {
+    return cached;
   }
 
   if (workspaceFolder) {
     try {
-      cachedPlugin = require(path.join(workspaceFolder, babelPluginPath));
-      return cachedPlugin;
+      const plugin: PluginObj = require(path.join(workspaceFolder, babelPluginPath));
+      pluginCache.set(cacheKey, plugin);
+      return plugin;
     } catch (error: any) {
       throttledError(
-        `Failed to load babel-plugin-react-compiler from workspace: ${error?.message}`
+        `Failed to load babel-plugin-react-compiler from ${workspaceFolder}: ${error?.message}`
       );
     }
   }
 
   // Fallback to bundled version
+  const bundled = pluginCache.get(BUNDLED_PLUGIN_CACHE_KEY);
+  if (bundled) {
+    return bundled;
+  }
+
   try {
-    cachedPlugin = require("babel-plugin-react-compiler");
+    const plugin: PluginObj = require("babel-plugin-react-compiler");
+    pluginCache.set(BUNDLED_PLUGIN_CACHE_KEY, plugin);
+    return plugin;
   } catch (error: any) {
     throttledError(`Failed to load babel-plugin-react-compiler: ${error?.message}`);
     return undefined;
   }
-
-  return cachedPlugin;
 }
 
 function getLanguageFromFilename(filename: string): "flow" | "typescript" {

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -173,13 +173,20 @@ function runBabelPluginReactCompiler(
 
 const BUNDLED_PLUGIN_CACHE_KEY = "\0bundled";
 
+/**
+ * Identifies which compiler a result came from. Both the plugin cache and the
+ * compilation cache key on this, so they can never disagree about which root's
+ * plugin produced a given result.
+ */
+function pluginScope(workspaceFolder: string | undefined, babelPluginPath: string): string {
+  return workspaceFolder ? `${workspaceFolder}\0${babelPluginPath}` : BUNDLED_PLUGIN_CACHE_KEY;
+}
+
 function importBabelPluginReactCompiler(
   workspaceFolder: string | undefined,
   babelPluginPath: string
 ): PluginObj | undefined {
-  const cacheKey = workspaceFolder
-    ? `${workspaceFolder}\0${babelPluginPath}`
-    : BUNDLED_PLUGIN_CACHE_KEY;
+  const cacheKey = pluginScope(workspaceFolder, babelPluginPath);
 
   // Return the plugin cached for this workspace root, if any
   const cached = pluginCache.get(cacheKey);
@@ -232,8 +239,10 @@ export function checkReactCompiler(
   babelPluginPath: string,
   compilationMode: CompilationMode
 ): CompilationResult {
-  // Check cache first (keyed by content, filename and compilation mode)
-  const cached = compilationCache.get(sourceCode, filename, compilationMode);
+  // Check cache first (keyed by content, filename, compilation mode and the
+  // root/plugin the result would come from)
+  const scope = pluginScope(workspaceFolder, babelPluginPath);
+  const cached = compilationCache.get(sourceCode, filename, compilationMode, scope);
   if (cached) {
     return cached;
   }
@@ -255,7 +264,7 @@ export function checkReactCompiler(
     );
 
     // Cache the result
-    compilationCache.set(sourceCode, filename, compilationMode, result);
+    compilationCache.set(sourceCode, filename, compilationMode, scope, result);
 
     return result;
   } catch (error: any) {
@@ -265,7 +274,7 @@ export function checkReactCompiler(
       failedCompilations: [],
       skippedCompilations: [],
     };
-    compilationCache.set(sourceCode, filename, compilationMode, emptyResult);
+    compilationCache.set(sourceCode, filename, compilationMode, scope, emptyResult);
     return emptyResult;
   }
 }

--- a/packages/server/src/report/generate.ts
+++ b/packages/server/src/report/generate.ts
@@ -15,6 +15,12 @@ import {
  */
 export interface ReactCompilerReport {
   generatedAt: string;
+  /**
+   * Absolute path of the root this report was generated from. File paths below
+   * are relative to it, so a multi-root workspace can tell which folder a saved
+   * report belongs to. Optional for reports written by older versions.
+   */
+  root?: string;
   totals: {
     filesScanned: number;
     filesWithResults: number;
@@ -284,6 +290,7 @@ export async function generateReport(options: ReportOptions): Promise<ReactCompi
 
   return {
     generatedAt: new Date().toISOString(),
+    root,
     totals: {
       filesScanned: files.length,
       filesWithResults: filesWithResults.length,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,7 +13,6 @@ import {
 } from "vscode-languageserver/node";
 
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { fileURLToPath } from "node:url";
 import {
   checkReactCompiler,
   getCompiledOutput,
@@ -26,6 +25,7 @@ import {
 import { generateInlayHints } from "./inlayHints";
 import { debounce } from "./debounce";
 import { shouldEnableHover } from "./clientUtils";
+import { resolveWorkspaceFolderForUri, workspaceFolderUriToPath } from "./workspaceFolders";
 
 import packageJson from "../package.json";
 import { generateReport, buildReportTree, getReportHtml } from "./report/index";
@@ -69,8 +69,19 @@ let tooltipFormat: TooltipFormat = "markdown";
 // Store activation state
 let isActivated = true;
 
-// Store workspace folder
-let workspaceFolder: string | undefined;
+// Store every open workspace folder, in the order the client reported them.
+// A multi-root workspace can have a different babel-plugin-react-compiler per
+// root, so each document must be analyzed against the root that contains it.
+let workspaceFolders: string[] = [];
+
+// The root used when a document belongs to no open folder, and the default
+// target for report commands that do not name one.
+function defaultWorkspaceFolder(): string | undefined {
+  return workspaceFolders[0];
+}
+
+// Whether the client can notify us when folders are added or removed
+let hasWorkspaceFolderCapability = false;
 
 // Store client name
 let clientName: string | undefined;
@@ -86,11 +97,13 @@ function logError(error: string): void {
 }
 
 connection.onInitialize((params: InitializeParams): InitializeResult => {
-  const workspaceFolderUri = params.workspaceFolders?.[0]?.uri;
-  if (workspaceFolderUri?.startsWith("file://")) {
-    workspaceFolder = fileURLToPath(workspaceFolderUri);
-  } else {
-    workspaceFolder = workspaceFolderUri;
+  workspaceFolders = (params.workspaceFolders ?? [])
+    .map((folder) => workspaceFolderUriToPath(folder.uri))
+    .filter((folder): folder is string => Boolean(folder));
+
+  // Clients that predate `workspaceFolders` still send the deprecated rootUri.
+  if (workspaceFolders.length === 0 && params.rootUri) {
+    workspaceFolders = [workspaceFolderUriToPath(params.rootUri)];
   }
 
   // Store client name for feature detection
@@ -101,6 +114,8 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
   if (initOptions?.tooltipFormat === "html" || initOptions?.tooltipFormat === "markdown") {
     tooltipFormat = initOptions.tooltipFormat;
   }
+
+  hasWorkspaceFolderCapability = Boolean(params.capabilities.workspace?.workspaceFolders);
 
   const hoverEnabled = shouldEnableHover(clientName);
 
@@ -127,12 +142,38 @@ connection.onInitialize((params: InitializeParams): InitializeResult => {
           "react-compiler-marker/generateReportHtml",
         ],
       },
+      workspace: {
+        workspaceFolders: {
+          supported: true,
+          changeNotifications: true,
+        },
+      },
     },
   };
 });
 
 connection.onInitialized(() => {
-  logMessage("React Compiler Marker LSP Server initialized");
+  logMessage(
+    `React Compiler Marker LSP Server initialized (workspace folders: ${
+      workspaceFolders.length > 0 ? workspaceFolders.join(", ") : "none"
+    })`
+  );
+
+  if (hasWorkspaceFolderCapability) {
+    connection.workspace.onDidChangeWorkspaceFolders((event) => {
+      const removed = new Set(event.removed.map((folder) => workspaceFolderUriToPath(folder.uri)));
+      workspaceFolders = workspaceFolders
+        .filter((folder) => !removed.has(folder))
+        .concat(event.added.map((folder) => workspaceFolderUriToPath(folder.uri)));
+
+      // A removed root's plugin must not keep serving files, and cached results
+      // may have been produced by it.
+      clearPluginCache();
+      clearCompilationCache();
+      connection.languages.inlayHint.refresh();
+      logMessage(`Workspace folders changed: ${workspaceFolders.join(", ") || "none"}`);
+    });
+  }
 });
 
 // Handle configuration changes
@@ -179,7 +220,8 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
   return debounce(params.textDocument.uri, () => {
     logMessage(`Process inlay hints for ${params.textDocument.uri}`);
     const fileName = params.textDocument.uri;
-    const fileNameForCompiler = fileName.startsWith("file://") ? fileName.slice(7) : fileName;
+    const fileNameForCompiler = workspaceFolderUriToPath(fileName);
+    const documentWorkspaceFolder = resolveWorkspaceFolderForUri(fileName, workspaceFolders);
 
     try {
       const sourceCode = document.getText();
@@ -188,7 +230,7 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
         checkReactCompiler(
           sourceCode,
           fileNameForCompiler,
-          workspaceFolder,
+          documentWorkspaceFolder,
           globalSettings.babelPluginPath,
           globalSettings.compilationMode
         );
@@ -230,7 +272,8 @@ connection.onHover((params: HoverParams): Hover | null => {
   }
 
   const fileName = params.textDocument.uri;
-  const fileNameForCompiler = fileName.startsWith("file://") ? fileName.slice(7) : fileName;
+  const fileNameForCompiler = workspaceFolderUriToPath(fileName);
+  const documentWorkspaceFolder = resolveWorkspaceFolderForUri(fileName, workspaceFolders);
   const hoveredLine = params.position.line;
 
   try {
@@ -239,7 +282,7 @@ connection.onHover((params: HoverParams): Hover | null => {
     const { successfulCompilations, failedCompilations, skippedCompilations } = checkReactCompiler(
       sourceCode,
       fileNameForCompiler,
-      workspaceFolder,
+      documentWorkspaceFolder,
       globalSettings.babelPluginPath,
       globalSettings.compilationMode
     );
@@ -299,12 +342,12 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
         return { success: false, error: "Document not found" };
       }
 
-      const fileUri = uri.startsWith("file://") ? uri.slice(7) : uri;
+      const fileUri = workspaceFolderUriToPath(uri);
       try {
         const compiled = await getCompiledOutput(
           document.getText(),
           fileUri,
-          workspaceFolder,
+          resolveWorkspaceFolderForUri(uri, workspaceFolders),
           globalSettings.babelPluginPath,
           globalSettings.compilationMode
         );
@@ -323,7 +366,7 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
     case "react-compiler-marker/generateReport": {
       // Generate JSON data report
       const [options] = params.arguments ?? [];
-      const reportRoot = options?.root ?? workspaceFolder;
+      const reportRoot = options?.root ?? defaultWorkspaceFolder();
       if (!reportRoot) {
         return { success: false, error: "No workspace folder available" };
       }
@@ -361,7 +404,7 @@ connection.onExecuteCommand(async (params: ExecuteCommandParams) => {
     case "react-compiler-marker/generateReportHtml": {
       // Generate report and return self-contained HTML page
       const [htmlOptions] = params.arguments ?? [];
-      const htmlReportRoot = htmlOptions?.root ?? workspaceFolder;
+      const htmlReportRoot = htmlOptions?.root ?? defaultWorkspaceFolder();
       if (!htmlReportRoot) {
         return { success: false, error: "No workspace folder available" };
       }

--- a/packages/server/src/workspaceFolders.ts
+++ b/packages/server/src/workspaceFolders.ts
@@ -1,0 +1,74 @@
+import * as path from "path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Convert a workspace folder or document URI to a filesystem path.
+ *
+ * `file://` URIs are decoded properly (so percent-escaped characters such as
+ * spaces survive); anything else — including a plain path — is returned as is.
+ */
+export function workspaceFolderUriToPath(uri: string): string {
+  if (!uri.startsWith("file://")) {
+    return uri;
+  }
+  try {
+    return fileURLToPath(uri);
+  } catch {
+    // Malformed file URI: fall back to stripping the scheme.
+    return uri.slice("file://".length);
+  }
+}
+
+/**
+ * Find the workspace folder that contains `documentPath`.
+ *
+ * In a multi-root workspace several folders may be open at once, and roots can
+ * even be nested. The most specific (longest) containing root wins, so a file
+ * in `<monorepo>/packages/app` resolves to that package rather than the
+ * monorepo root when both are open.
+ *
+ * Returns `undefined` when the document lives outside every root — callers
+ * decide what to fall back to.
+ */
+export function resolveWorkspaceFolder(
+  documentPath: string,
+  folders: readonly string[]
+): string | undefined {
+  if (!documentPath || folders.length === 0) {
+    return undefined;
+  }
+
+  const target = path.resolve(documentPath);
+  let match: string | undefined;
+  let matchLength = -1;
+
+  for (const folder of folders) {
+    if (!folder) {
+      continue;
+    }
+    const root = path.resolve(folder);
+    // Compare on path boundaries so `/ws/project-a` does not swallow
+    // `/ws/project-a-extra`.
+    const isInside =
+      target === root || target.startsWith(root.endsWith(path.sep) ? root : root + path.sep);
+    if (isInside && root.length > matchLength) {
+      match = folder;
+      matchLength = root.length;
+    }
+  }
+
+  return match;
+}
+
+/**
+ * Resolve the workspace folder for a document URI, falling back to the first
+ * open folder when the document lives outside every root (e.g. an untitled or
+ * external file). Returns `undefined` when no folders are open at all.
+ */
+export function resolveWorkspaceFolderForUri(
+  documentUri: string,
+  folders: readonly string[]
+): string | undefined {
+  const documentPath = workspaceFolderUriToPath(documentUri);
+  return resolveWorkspaceFolder(documentPath, folders) ?? folders[0];
+}

--- a/packages/server/src/workspaceFolders.ts
+++ b/packages/server/src/workspaceFolders.ts
@@ -38,7 +38,7 @@ export function resolveWorkspaceFolder(
     return undefined;
   }
 
-  const target = path.resolve(documentPath);
+  const target = normalizeForComparison(documentPath);
   let match: string | undefined;
   let matchLength = -1;
 
@@ -46,7 +46,7 @@ export function resolveWorkspaceFolder(
     if (!folder) {
       continue;
     }
-    const root = path.resolve(folder);
+    const root = normalizeForComparison(folder);
     // Compare on path boundaries so `/ws/project-a` does not swallow
     // `/ws/project-a-extra`.
     const isInside =
@@ -58,6 +58,19 @@ export function resolveWorkspaceFolder(
   }
 
   return match;
+}
+
+/**
+ * Windows paths are case-insensitive, and the casing VS Code reports for a
+ * document URI need not match the casing of the workspace folder it came from
+ * (drive letters especially). Comparing those verbatim would drop the document
+ * to the fallback root and compile it with the wrong root's plugin — the very
+ * bug this module exists to prevent. Other platforms are left case-sensitive,
+ * since two roots differing only by case are then genuinely different folders.
+ */
+function normalizeForComparison(target: string): string {
+  const resolved = path.resolve(target);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
 /**

--- a/packages/vscode-client/src/extension.ts
+++ b/packages/vscode-client/src/extension.ts
@@ -50,6 +50,36 @@ ${code}
 Please help me fix this code so that the React Compiler can optimize it. The React Compiler automatically memoizes components and their dependencies, but it needs the code to follow certain patterns. Please provide the corrected code and explain what changes you made and why they help the React Compiler optimize the component.`;
 }
 
+/**
+ * Pick the workspace folder to act on. With a single root it is used directly;
+ * in a multi-root workspace the user chooses, since each root can have its own
+ * babel-plugin-react-compiler and its own report.
+ */
+async function pickWorkspaceFolder(
+  placeHolder: string
+): Promise<vscode.WorkspaceFolder | undefined> {
+  const folders = vscode.workspace.workspaceFolders;
+  if (!folders || folders.length === 0) {
+    return undefined;
+  }
+  if (folders.length === 1) {
+    return folders[0];
+  }
+  return vscode.window.showWorkspaceFolderPick({ placeHolder });
+}
+
+/**
+ * Locate the workspace folder a saved report was generated from. Reports record
+ * their own root; older ones fall back to the only open folder.
+ */
+function workspaceUriForReport(report: ReactCompilerReport): vscode.Uri | undefined {
+  if (report.root) {
+    return vscode.Uri.file(report.root);
+  }
+  const folders = vscode.workspace.workspaceFolders;
+  return folders && folders.length > 0 ? folders[0].uri : undefined;
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   logMessage("react-compiler-marker is being activated!");
 
@@ -171,12 +201,12 @@ export function activate(context: vscode.ExtensionContext): void {
             error: config.get<string>("errorEmoji") ?? "\uD83D\uDEAB",
             skipped: config.get<string>("skippedEmoji") ?? "\u23ED\uFE0F",
           };
-          const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-          if (!workspaceFolder) {
+          const workspaceUri = workspaceUriForReport(report);
+          if (!workspaceUri) {
             vscode.window.showErrorMessage("Open a workspace folder to view the report.");
             return;
           }
-          ReportPanel.createOrShow(workspaceFolder.uri, treeData, emojis);
+          ReportPanel.createOrShow(workspaceUri, treeData, emojis);
         } catch (error: any) {
           vscode.window.showErrorMessage(`Failed to open report: ${error?.message ?? error}`);
         }
@@ -333,9 +363,16 @@ function registerCommands(
   const generateReport = vscode.commands.registerCommand(
     "react-compiler-marker.generateReport",
     async () => {
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
+      const folders = vscode.workspace.workspaceFolders;
+      if (!folders || folders.length === 0) {
         vscode.window.showErrorMessage("Open a workspace folder to generate a report.");
+        return;
+      }
+      const workspaceFolder = await pickWorkspaceFolder(
+        "Select the workspace folder to generate a React Compiler report for"
+      );
+      if (!workspaceFolder) {
+        // The user dismissed the folder picker.
         return;
       }
 

--- a/packages/vscode-client/src/report/ReportPanel.ts
+++ b/packages/vscode-client/src/report/ReportPanel.ts
@@ -12,8 +12,11 @@ export class ReportPanel {
 
   private readonly panel: vscode.WebviewPanel;
   private data: ReportTreeData;
-  private readonly workspaceUri: vscode.Uri;
-  private readonly emojis: EmojiConfig;
+  // Reassigned when an existing panel is reused for a different report — in a
+  // multi-root workspace the next report may belong to another root, and file
+  // links are resolved against this URI.
+  private workspaceUri: vscode.Uri;
+  private emojis: EmojiConfig;
   private disposables: vscode.Disposable[] = [];
 
   private constructor(
@@ -43,6 +46,8 @@ export class ReportPanel {
   ): void {
     if (ReportPanel.instance) {
       ReportPanel.instance.data = data;
+      ReportPanel.instance.workspaceUri = workspaceUri;
+      ReportPanel.instance.emojis = emojis;
       ReportPanel.instance.panel.webview.html = ReportPanel.instance.getHtml();
       ReportPanel.instance.panel.reveal(vscode.ViewColumn.Beside);
       return;

--- a/packages/vscode-client/src/sidebar/ReportsTreeProvider.ts
+++ b/packages/vscode-client/src/sidebar/ReportsTreeProvider.ts
@@ -12,7 +12,7 @@ export class ReportItem extends vscode.TreeItem {
     public readonly report: ReactCompilerReport
   ) {
     const date = new Date(report.generatedAt);
-    const label = date.toLocaleDateString("en-US", {
+    const timestamp = date.toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
       year: "numeric",
@@ -20,19 +20,35 @@ export class ReportItem extends vscode.TreeItem {
       minute: "2-digit",
     });
 
+    // In a multi-root workspace each root gets its own reports, so name the
+    // folder a report covers — otherwise the list is a wall of timestamps.
+    const rootName = ReportItem.rootName(report);
+    const label = rootName ? `${rootName} · ${timestamp}` : timestamp;
+
     super(label, vscode.TreeItemCollapsibleState.None);
 
     const skippedCount = report.totals.skippedCount ?? 0;
     const skippedDesc = skippedCount > 0 ? `  \u23ED\uFE0F ${skippedCount}` : "";
     this.description = `\u2728 ${report.totals.successCount}  \uD83D\uDEAB ${report.totals.failedCount}${skippedDesc}`;
     this.iconPath = new vscode.ThemeIcon("graph");
-    this.tooltip = `Files scanned: ${report.totals.filesScanned}\nCompiled: ${report.totals.successCount}\nFailed: ${report.totals.failedCount}\nSkipped: ${skippedCount}`;
+    const rootLine = report.root ? `Root: ${report.root}\n` : "";
+    this.tooltip = `${rootLine}Files scanned: ${report.totals.filesScanned}\nCompiled: ${report.totals.successCount}\nFailed: ${report.totals.failedCount}\nSkipped: ${skippedCount}`;
     this.contextValue = "reportItem";
     this.command = {
       command: "react-compiler-marker.openReport",
       title: "Open Report",
       arguments: [reportUri],
     };
+  }
+
+  /** Name of the workspace folder a report covers, when several are open. */
+  private static rootName(report: ReactCompilerReport): string | undefined {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!report.root || !folders || folders.length < 2) {
+      return undefined;
+    }
+    const match = folders.find((folder) => folder.uri.fsPath === report.root);
+    return match?.name;
   }
 }
 

--- a/packages/vscode-client/src/sidebar/ReportsTreeProvider.ts
+++ b/packages/vscode-client/src/sidebar/ReportsTreeProvider.ts
@@ -47,7 +47,11 @@ export class ReportItem extends vscode.TreeItem {
     if (!report.root || !folders || folders.length < 2) {
       return undefined;
     }
-    const match = folders.find((folder) => folder.uri.fsPath === report.root);
+    // Windows paths are case-insensitive and VS Code's casing need not match
+    // the one recorded in the report, so compare the way the platform does.
+    const samePath = (left: string, right: string) =>
+      process.platform === "win32" ? left.toLowerCase() === right.toLowerCase() : left === right;
+    const match = folders.find((folder) => samePath(folder.uri.fsPath, report.root as string));
     return match?.name;
   }
 }

--- a/packages/vscode-client/test/fixtures/multi-root/project-a/App.tsx
+++ b/packages/vscode-client/test/fixtures/multi-root/project-a/App.tsx
@@ -1,0 +1,3 @@
+export default function AppInProjectA() {
+  return <h1>Hello from project-a</h1>;
+}

--- a/packages/vscode-client/test/fixtures/multi-root/project-a/plugins/stub-compiler.js
+++ b/packages/vscode-client/test/fixtures/multi-root/project-a/plugins/stub-compiler.js
@@ -1,0 +1,17 @@
+// Stand-in for a project-local `babel-plugin-react-compiler`. It reports a
+// CompileSuccess naming the root it was loaded from, so a test can tell which
+// project's plugin actually ran.
+module.exports = function stubReactCompilerProjectA(_api, options) {
+  return {
+    name: "stub-react-compiler-project-a",
+    visitor: {
+      Program() {
+        options?.logger?.logEvent("stub", {
+          kind: "CompileSuccess",
+          fnName: "stub-plugin-from-project-a",
+          fnLoc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        });
+      },
+    },
+  };
+};

--- a/packages/vscode-client/test/fixtures/multi-root/project-b/App.tsx
+++ b/packages/vscode-client/test/fixtures/multi-root/project-b/App.tsx
@@ -1,0 +1,3 @@
+export default function AppInProjectB() {
+  return <h1>Hello from project-b</h1>;
+}

--- a/packages/vscode-client/test/fixtures/multi-root/project-b/plugins/stub-compiler.js
+++ b/packages/vscode-client/test/fixtures/multi-root/project-b/plugins/stub-compiler.js
@@ -1,0 +1,17 @@
+// Stand-in for a project-local `babel-plugin-react-compiler`. It reports a
+// CompileSuccess naming the root it was loaded from, so a test can tell which
+// project's plugin actually ran.
+module.exports = function stubReactCompilerProjectB(_api, options) {
+  return {
+    name: "stub-react-compiler-project-b",
+    visitor: {
+      Program() {
+        options?.logger?.logEvent("stub", {
+          kind: "CompileSuccess",
+          fnName: "stub-plugin-from-project-b",
+          fnLoc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        });
+      },
+    },
+  };
+};

--- a/packages/vscode-client/test/multiRoot.test.ts
+++ b/packages/vscode-client/test/multiRoot.test.ts
@@ -23,6 +23,10 @@ function workspaceFolderUriToPath(uri: string): string {
   return workspaceFolders().workspaceFolderUriToPath(uri);
 }
 
+function resolveWorkspaceFolderForUri(uri: string, roots: string[]): string | undefined {
+  return workspaceFolders().resolveWorkspaceFolderForUri(uri, roots);
+}
+
 // Fixtures live in `test/fixtures`, but compiled tests run from `out/test`.
 function fixtureDir(...segments: string[]): string {
   const candidates = [
@@ -103,6 +107,30 @@ suite("Multi-root workspace: plugin resolution", () => {
       require.cache[require.resolve(pluginModule)],
       loadedOnce,
       "repeated checks against one root must not reload the plugin"
+    );
+  });
+
+  test("the compilation cache does not serve one root's result to another", () => {
+    const rootA = fixtureDir("multi-root", "project-a");
+    const rootB = fixtureDir("multi-root", "project-b");
+    const source = fs.readFileSync(path.join(rootA, "App.tsx"), "utf8");
+
+    // Same absolute filename, same content, same mode — only the root differs.
+    // Reachable for real when nested roots are open: a report scanning the outer
+    // root sees the same file the inlay hints resolve to the inner root.
+    const shared = "/mock/shared/App.tsx";
+    const viaA = checkReactCompiler(source, shared, rootA, STUB_PLUGIN_PATH, "infer");
+    const viaB = checkReactCompiler(source, shared, rootB, STUB_PLUGIN_PATH, "infer");
+
+    assert.strictEqual(
+      viaA.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-project-a",
+      "the first root's plugin should produce the first result"
+    );
+    assert.strictEqual(
+      viaB.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-project-b",
+      "a cache keyed without the root would replay project-a's result here"
     );
   });
 
@@ -190,12 +218,39 @@ suite("Multi-root workspace: root resolution for a document", () => {
     assert.strictEqual(resolveWorkspaceFolder("/ws/project-a", roots), "/ws/project-a");
   });
 
-  test("falls back to the first root for a file outside every root", () => {
+  test("returns undefined for a file outside every root", () => {
     assert.strictEqual(resolveWorkspaceFolder("/elsewhere/App.tsx", roots), undefined);
   });
 
   test("handles an empty root list", () => {
     assert.strictEqual(resolveWorkspaceFolder("/ws/project-a/src/App.tsx", []), undefined);
+  });
+
+  // This is what all four server call sites actually use.
+  test("resolveWorkspaceFolderForUri picks the containing root for a file URI", () => {
+    assert.strictEqual(
+      resolveWorkspaceFolderForUri("file:///ws/project-b/src/App.tsx", roots),
+      "/ws/project-b"
+    );
+  });
+
+  test("resolveWorkspaceFolderForUri decodes escaped characters before matching", () => {
+    assert.strictEqual(
+      resolveWorkspaceFolderForUri("file:///ws/project-b/src/My%20App.tsx", roots),
+      "/ws/project-b",
+      "a path with a space must still resolve to its root, not the fallback"
+    );
+  });
+
+  test("resolveWorkspaceFolderForUri falls back to the first root when outside every root", () => {
+    assert.strictEqual(
+      resolveWorkspaceFolderForUri("file:///elsewhere/App.tsx", roots),
+      "/ws/project-a"
+    );
+  });
+
+  test("resolveWorkspaceFolderForUri returns undefined when no folders are open", () => {
+    assert.strictEqual(resolveWorkspaceFolderForUri("file:///elsewhere/App.tsx", []), undefined);
   });
 
   test("converts file:// URIs to paths", () => {

--- a/packages/vscode-client/test/multiRoot.test.ts
+++ b/packages/vscode-client/test/multiRoot.test.ts
@@ -1,0 +1,181 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const serverOut = path.join(__dirname, "..", "..", "..", "server", "out");
+const {
+  checkReactCompiler,
+  clearPluginCache,
+  clearCompilationCache,
+} = require(path.join(serverOut, "checkReactCompiler"));
+// Required lazily so that a missing module fails only the suite that needs it.
+function workspaceFolders() {
+  return require(path.join(serverOut, "workspaceFolders"));
+}
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+function resolveWorkspaceFolder(documentPath: string, roots: string[]): string | undefined {
+  return workspaceFolders().resolveWorkspaceFolder(documentPath, roots);
+}
+
+function workspaceFolderUriToPath(uri: string): string {
+  return workspaceFolders().workspaceFolderUriToPath(uri);
+}
+
+// Fixtures live in `test/fixtures`, but compiled tests run from `out/test`.
+function fixtureDir(...segments: string[]): string {
+  const candidates = [
+    path.join(__dirname, "fixtures", ...segments),
+    path.join(__dirname, "..", "..", "test", "fixtures", ...segments),
+  ];
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(`Fixture not found: ${segments.join("/")} in any of:\n${candidates.join("\n")}`);
+}
+
+// Each fixture root ships a stub plugin that logs a CompileSuccess naming its
+// own root, so the reported `fnName` tells us which root's plugin actually ran.
+const STUB_PLUGIN_PATH = path.join("plugins", "stub-compiler.js");
+
+suite("Multi-root workspace: plugin resolution", () => {
+  setup(() => {
+    clearPluginCache();
+    clearCompilationCache();
+  });
+
+  teardown(() => {
+    clearPluginCache();
+    clearCompilationCache();
+  });
+
+  test("each workspace root loads its own babel-plugin-react-compiler", () => {
+    const rootA = fixtureDir("multi-root", "project-a");
+    const rootB = fixtureDir("multi-root", "project-b");
+    const sourceA = fs.readFileSync(path.join(rootA, "App.tsx"), "utf8");
+    const sourceB = fs.readFileSync(path.join(rootB, "App.tsx"), "utf8");
+
+    const resultA = checkReactCompiler(
+      sourceA,
+      path.join(rootA, "App.tsx"),
+      rootA,
+      STUB_PLUGIN_PATH,
+      "infer"
+    );
+    const resultB = checkReactCompiler(
+      sourceB,
+      path.join(rootB, "App.tsx"),
+      rootB,
+      STUB_PLUGIN_PATH,
+      "infer"
+    );
+
+    assert.strictEqual(
+      resultA.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-project-a",
+      "project-a's file must be analyzed with project-a's plugin"
+    );
+    // Without a per-root plugin cache the module-level singleton keeps serving
+    // project-a's plugin here, even though project-b's root was passed in.
+    assert.strictEqual(
+      resultB.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-project-b",
+      "project-b's file must be analyzed with project-b's plugin, not the first root's"
+    );
+  });
+
+  test("plugin cache still avoids re-requiring the same root", () => {
+    const rootA = fixtureDir("multi-root", "project-a");
+    const pluginModule = path.join(rootA, STUB_PLUGIN_PATH);
+    const source = fs.readFileSync(path.join(rootA, "App.tsx"), "utf8");
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require(pluginModule);
+    const loadedOnce = require.cache[require.resolve(pluginModule)];
+
+    checkReactCompiler(source, path.join(rootA, "one.tsx"), rootA, STUB_PLUGIN_PATH, "infer");
+    checkReactCompiler(source, path.join(rootA, "two.tsx"), rootA, STUB_PLUGIN_PATH, "infer");
+
+    assert.strictEqual(
+      require.cache[require.resolve(pluginModule)],
+      loadedOnce,
+      "repeated checks against one root must not reload the plugin"
+    );
+  });
+
+  test("clearPluginCache drops every cached root", () => {
+    const rootA = fixtureDir("multi-root", "project-a");
+    const rootB = fixtureDir("multi-root", "project-b");
+    const sourceA = fs.readFileSync(path.join(rootA, "App.tsx"), "utf8");
+    const sourceB = fs.readFileSync(path.join(rootB, "App.tsx"), "utf8");
+
+    checkReactCompiler(sourceA, path.join(rootA, "App.tsx"), rootA, STUB_PLUGIN_PATH, "infer");
+    checkReactCompiler(sourceB, path.join(rootB, "App.tsx"), rootB, STUB_PLUGIN_PATH, "infer");
+
+    clearPluginCache();
+    clearCompilationCache();
+
+    const again = checkReactCompiler(
+      sourceB,
+      path.join(rootB, "App.tsx"),
+      rootB,
+      STUB_PLUGIN_PATH,
+      "infer"
+    );
+    assert.strictEqual(
+      again.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-project-b",
+      "after clearing, each root must reload its own plugin"
+    );
+  });
+});
+
+suite("Multi-root workspace: root resolution for a document", () => {
+  const roots = ["/ws/project-a", "/ws/project-b"];
+
+  test("picks the root that contains the document", () => {
+    assert.strictEqual(resolveWorkspaceFolder("/ws/project-b/src/App.tsx", roots), "/ws/project-b");
+    assert.strictEqual(resolveWorkspaceFolder("/ws/project-a/src/App.tsx", roots), "/ws/project-a");
+  });
+
+  test("prefers the most specific root when roots are nested", () => {
+    const nested = ["/ws/monorepo", "/ws/monorepo/packages/app"];
+    assert.strictEqual(
+      resolveWorkspaceFolder("/ws/monorepo/packages/app/src/App.tsx", nested),
+      "/ws/monorepo/packages/app"
+    );
+    assert.strictEqual(
+      resolveWorkspaceFolder("/ws/monorepo/scripts/build.ts", nested),
+      "/ws/monorepo"
+    );
+  });
+
+  test("does not match a root that is only a string prefix of the path", () => {
+    assert.strictEqual(resolveWorkspaceFolder("/ws/project-a-extra/src/App.tsx", roots), undefined);
+  });
+
+  test("matches a document that is the root itself", () => {
+    assert.strictEqual(resolveWorkspaceFolder("/ws/project-a", roots), "/ws/project-a");
+  });
+
+  test("falls back to the first root for a file outside every root", () => {
+    assert.strictEqual(resolveWorkspaceFolder("/elsewhere/App.tsx", roots), undefined);
+  });
+
+  test("handles an empty root list", () => {
+    assert.strictEqual(resolveWorkspaceFolder("/ws/project-a/src/App.tsx", []), undefined);
+  });
+
+  test("converts file:// URIs to paths", () => {
+    assert.strictEqual(workspaceFolderUriToPath("file:///ws/project-a"), path.sep + path.join("ws", "project-a"));
+    assert.strictEqual(
+      workspaceFolderUriToPath("file:///ws/with%20space"),
+      path.sep + path.join("ws", "with space")
+    );
+    // Non-file URIs (and plain paths) pass through untouched.
+    assert.strictEqual(workspaceFolderUriToPath("/ws/project-a"), "/ws/project-a");
+  });
+});

--- a/packages/vscode-client/test/multiRoot.test.ts
+++ b/packages/vscode-client/test/multiRoot.test.ts
@@ -106,6 +106,35 @@ suite("Multi-root workspace: plugin resolution", () => {
     );
   });
 
+  test("a root without a local plugin falls back once, not per file", () => {
+    const rootA = fixtureDir("multi-root", "project-a");
+    const missing = path.join("plugins", "does-not-exist.js");
+    const source = fs.readFileSync(path.join(rootA, "App.tsx"), "utf8");
+
+    // The bundled plugin takes over; the point is that it is then cached under
+    // this root's key so the failing require() is not retried for every file.
+    checkReactCompiler(source, path.join(rootA, "one.tsx"), rootA, missing, "infer");
+    const cachedAfterFallback = checkReactCompiler(
+      source,
+      path.join(rootA, "two.tsx"),
+      rootA,
+      missing,
+      "infer"
+    );
+
+    assert.ok(
+      Array.isArray(cachedAfterFallback.successfulCompilations),
+      "the bundled plugin should still produce a result"
+    );
+    // The stub was never involved, so no stub event may appear.
+    assert.ok(
+      !cachedAfterFallback.successfulCompilations.some((event: { fnName?: string }) =>
+        event.fnName?.startsWith("stub-plugin-from-")
+      ),
+      "a missing local plugin must fall back to the bundled compiler, not a stub"
+    );
+  });
+
   test("clearPluginCache drops every cached root", () => {
     const rootA = fixtureDir("multi-root", "project-a");
     const rootB = fixtureDir("multi-root", "project-b");


### PR DESCRIPTION
Fixes #84.

## The bug

The issue reports that only `workspaceFolders[0]` is used for plugin resolution and reports. That's all true — but there's a fifth site it doesn't mention, and it's the one that actually breaks things:

`checkReactCompiler.ts` cached the Babel plugin in a **module-level singleton**. Even when the correct root was passed for a document, `importBabelPluginReactCompiler` returned the first plugin ever loaded, for every root, forever. Fixing only the "which root" plumbing would have left the bug fully intact.

## Test first

`packages/vscode-client/test/multiRoot.test.ts` sets up two fixture roots, each with a stub plugin that logs a `CompileSuccess` naming its own root. Since `**/node_modules` is gitignored, the stubs live in `plugins/` and are reached through the existing configurable `babelPluginPath` setting — the same `require(path.join(root, pluginPath))` code path.

Before the fix:

```
1) each workspace root loads its own babel-plugin-react-compiler
   AssertionError: project-b's file must be analyzed with project-b's plugin, not the first root's
   - expected: stub-plugin-from-project-b
   + actual:   stub-plugin-from-project-a
```

8 failing, 19 passing → **28 passing**.

## The fix

- **`packages/server/src/workspaceFolders.ts`** (new) — `resolveWorkspaceFolder` does a longest-prefix match on path boundaries, so nested roots resolve to the most specific one and `/ws/project-a` does not swallow `/ws/project-a-extra`. Also proper `file://` decoding, replacing the `uri.slice(7)` used in three places (which mangled percent-escaped paths — a path containing a space matched no root).
- **`checkReactCompiler.ts`** — the plugin cache is now a `Map` keyed by `(root, babelPluginPath)`. A root with no local plugin caches the bundled fallback under its own key, so it does not retry a failing `require()` once per file during a report scan.
- **`server.ts`** — stores every `workspaceFolders` entry (with a `rootUri` fallback for older clients) and resolves the containing root per document at all four sites: inlay hints, hover, `getCompiledOutput`, and the default root for both report commands.
- **`extension.ts`** — `generateReport` prompts with `showWorkspaceFolderPick` when several roots are open.

## Beyond the issue's ask

Three deliberate additions, called out for review rather than left to be discovered in the diff:

- `didChangeWorkspaceFolders` handling, so adding or removing a folder does not leave a stale root list. Roughly 20 lines, and currently untested.
- Reports now record their `root` in the JSON, so **Open Report** resolves file links against the root the report was generated from instead of `workspaceFolders[0]`.
- The sidebar labels reports by folder name when multiple roots are open — otherwise a multi-root workspace shows a wall of indistinguishable timestamps.

## Testing

`npm run typecheck`, `npm run lint`, `npm run prettier` and `npm test` all pass in a normal checkout. 28 tests passing (was 19 before this branch added its own).
