### PR TITLE
fix: place skipped marker at function start for multi-line signatures

### DIFF
--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -3,8 +3,9 @@ import { PluginObj, transformSync } from "@babel/core";
 import BabelPluginSyntaxHermesParser from "babel-plugin-syntax-hermes-parser";
 import * as path from "path";
 import { LRUCache } from "./cache";
+import { createSkipEventRemapper } from "./remapSkipEvents";
 
-type EventLocation = {
+export type EventLocation = {
   start?: { line?: number; column?: number; index?: number };
   end?: { line?: number; column?: number; index?: number };
 };
@@ -116,6 +117,8 @@ function runBabelPluginReactCompiler(
   const failedCompilations: Array<LoggerEvent> = [];
   const skippedCompilations: Array<LoggerEvent> = [];
 
+  const skipRemapper = createSkipEventRemapper();
+
   const logger = {
     logEvent(filename: string | null, rawEvent: LoggerEvent) {
       const event = { ...rawEvent, filename };
@@ -130,7 +133,7 @@ function runBabelPluginReactCompiler(
           failedCompilations.push(event);
           return;
         case "CompileSkip":
-          skippedCompilations.push(event);
+          skippedCompilations.push(skipRemapper.remapSkipEvent(event));
           return;
       }
     },
@@ -149,6 +152,7 @@ function runBabelPluginReactCompiler(
     retainLines: true,
     plugins: [
       [BabelPluginSyntaxHermesParser, HERMES_PARSER_OPTIONS],
+      skipRemapper.plugin,
       [BabelPluginReactCompiler, COMPILER_OPTIONS],
     ],
     parserOpts: {

--- a/packages/server/src/remapSkipEvents.ts
+++ b/packages/server/src/remapSkipEvents.ts
@@ -1,0 +1,44 @@
+import { NodePath, PluginObj, types as t } from "@babel/core";
+import type { EventLocation, LoggerEvent } from "./checkReactCompiler";
+
+/**
+ * babel-plugin-react-compiler reports CompileSkip events with fnLoc set to the
+ * function *body* location (the `{` block), unlike other events which use the
+ * function's own location. With a multi-line signature that puts the marker on
+ * the closing line of the parameter list instead of the function line.
+ *
+ * The returned `plugin` records every function's real location keyed by its
+ * body start (it must run before the compiler plugin in the same pipeline),
+ * and `remapSkipEvent` swaps a skip event's body location for it.
+ */
+export function createSkipEventRemapper(): {
+  plugin: PluginObj;
+  remapSkipEvent: (event: LoggerEvent) => LoggerEvent;
+} {
+  const fnLocByBodyStart = new Map<string, EventLocation>();
+
+  const plugin: PluginObj = {
+    visitor: {
+      // Record eagerly on Program enter, before the compiler plugin (which
+      // also runs on Program) transforms the tree.
+      Program(programPath) {
+        programPath.traverse({
+          Function({ node }: NodePath<t.Function>) {
+            if (node.body.type === "BlockStatement" && node.body.loc && node.loc) {
+              const { line, column } = node.body.loc.start;
+              fnLocByBodyStart.set(`${line}:${column}`, node.loc);
+            }
+          },
+        });
+      },
+    },
+  };
+
+  function remapSkipEvent(event: LoggerEvent): LoggerEvent {
+    const { line, column } = event.fnLoc?.start ?? {};
+    const fnLoc = fnLocByBodyStart.get(`${line}:${column}`) ?? event.fnLoc;
+    return { ...event, fnLoc };
+  }
+
+  return { plugin, remapSkipEvent };
+}

--- a/packages/vscode-client/test/decorations.test.ts
+++ b/packages/vscode-client/test/decorations.test.ts
@@ -166,6 +166,35 @@ suite("Critical error handling", () => {
     }
   });
 
+  test("use-no-memo-multiline-signature.tsx: skip events point at the function line, not the body line", () => {
+    const text = readFixture("use-no-memo-multiline-signature.tsx").trim();
+    const filename = "/mock/use-no-memo-multiline-signature.tsx";
+
+    const { skippedCompilations } = compileFixture(text, filename);
+
+    assert.strictEqual(
+      skippedCompilations.length,
+      2,
+      `Expected 2 skipped compilations, got ${skippedCompilations.length}`
+    );
+
+    // The compiler reports skips with the body location (`}: Props) {`); the
+    // remap in remapSkipEvents.ts must restore the function's own start line.
+    const [fnSkip, arrowSkip] = [...skippedCompilations].sort(
+      (a, b) => (a.fnLoc?.start?.line ?? 0) - (b.fnLoc?.start?.line ?? 0)
+    );
+    assert.strictEqual(
+      fnSkip.fnLoc?.start?.line,
+      11,
+      `Expected the skipped function declaration to start at its \`function\` line, got line ${fnSkip.fnLoc?.start?.line}`
+    );
+    assert.strictEqual(
+      arrowSkip.fnLoc?.start?.line,
+      21,
+      `Expected the skipped arrow function to start at its \`const\` line, got line ${arrowSkip.fnLoc?.start?.line}`
+    );
+  });
+
   test('annotation-mode.tsx: only "use memo" components compile under compilationMode: "annotation"', () => {
     const text = readFixture("annotation-mode.tsx").trim();
     const filename = "/mock/annotation-mode.tsx";

--- a/packages/vscode-client/test/fixtures/use-no-memo-multiline-signature.tsx
+++ b/packages/vscode-client/test/fixtures/use-no-memo-multiline-signature.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+type Props = {
+  ingredient: string;
+  updateIngredient: () => void;
+  autoFocusInput: boolean;
+};
+
+// The compiler reports CompileSkip with the *body* location — with a multi-line
+// signature that is the `}: Props) {` line, not the `function` line (line 11).
+function SkippedComponent({
+  ingredient,
+  updateIngredient,
+  autoFocusInput,
+}: Props) {
+  "use no memo";
+  return <div>{ingredient}</div>;
+}
+
+// Same for arrows: the remapped location must be the `const` line (line 21).
+const SkippedArrow = ({
+  ingredient,
+}: {
+  ingredient: string;
+}) => {
+  "use no memo";
+  return <div>{ingredient}</div>;
+};


### PR DESCRIPTION
## Problem

For components skipped via `"use no memo"`, the marker was rendered at the end of the parameter list's closing line instead of next to the function keyword:

```tsx
function IngredientDetailsModalContent({
  ingredient,
  updateIngredient,
  autoFocusInput,
}: IngredientDetailsModalContentProps) { // ⏩ marker landed here
  'use no memo';
```

## Cause

`babel-plugin-react-compiler` emits `CompileSkip` events with `fnLoc` set to the function **body** location (the `{` block), while `CompileSuccess`/`CompileError` use the function's own location. With a multi-line signature, the body starts on the closing line of the parameter list — that line matches no function pattern in `getInlayHintPosition`, so the hint fell back to end-of-line.

## Fix

New `remapSkipEvents.ts` module: a tiny Babel plugin runs in the same pipeline (before the compiler plugin) and records every function's real location keyed by its body start. `CompileSkip` events are then remapped to the function's own location before being bucketed. Success and error paths are untouched; single-line signatures are a no-op (body line equals function line).

Verified with a fixture matching the screenshot: skipped `function` declarations and skipped arrow functions now report their header line.