### PR TITLE
fix: port Zed client fixes into the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /server
 **/zed-client/target
 **/zed-client/extension.wasm
+
+# Plugin-discovery fixtures have to ship a real node_modules layout
+!packages/vscode-client/test/fixtures/**/node_modules/

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -1,6 +1,7 @@
 import { PluginObj, transformSync } from "@babel/core";
 // @ts-expect-error - no types
 import BabelPluginSyntaxHermesParser from "babel-plugin-syntax-hermes-parser";
+import * as fs from "fs";
 import * as path from "path";
 import { LRUCache } from "./cache";
 import { createSkipEventRemapper } from "./remapSkipEvents";
@@ -186,6 +187,73 @@ function pluginScope(workspaceFolder: string | undefined, babelPluginPath: strin
   return workspaceFolder ? `${workspaceFolder}\0${babelPluginPath}` : BUNDLED_PLUGIN_CACHE_KEY;
 }
 
+// Directories that never hold the workspace's own installs. `node_modules` is
+// on the list because a plugin nested inside one belongs to a dependency, not
+// to a package of this workspace.
+const IGNORED_SEARCH_DIRS = new Set(["node_modules", "dist", "build", "out", "coverage", "vendor"]);
+const MAX_SEARCH_DIRS = 5000;
+
+/**
+ * Look for `babelPluginPath` somewhere below `workspaceFolder`.
+ *
+ * A single root opened at the top of a monorepo usually has no plugin of its
+ * own: it is installed in the package that uses it (`apps/web/node_modules/…`).
+ * Without this search the root-level require misses and every file is analyzed
+ * with the compiler bundled into this server rather than the project's own.
+ *
+ * Breadth-first, so the shallowest install wins when several packages have one.
+ */
+function findPluginInWorkspace(
+  workspaceFolder: string,
+  babelPluginPath: string
+): string | undefined {
+  const queue = [workspaceFolder];
+  let scanned = 0;
+
+  while (queue.length > 0 && scanned < MAX_SEARCH_DIRS) {
+    const dir = queue.shift() as string;
+    scanned++;
+
+    // Probing follows symlinks on purpose: pnpm keeps the real package in its
+    // store and links it into each package's node_modules.
+    const candidate = path.join(dir, babelPluginPath);
+    if (fs.existsSync(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      // Unreadable directory (permissions, a stale mount): skip it.
+      continue;
+    }
+    for (const entry of entries) {
+      // Descend into plain directories only, since symlinks can loop.
+      if (
+        entry.isDirectory() &&
+        !entry.name.startsWith(".") &&
+        !IGNORED_SEARCH_DIRS.has(entry.name)
+      ) {
+        queue.push(path.join(dir, entry.name));
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function requirePlugin(modulePath: string | undefined): PluginObj | undefined {
+  if (!modulePath) {
+    return undefined;
+  }
+  try {
+    return require(modulePath);
+  } catch {
+    return undefined;
+  }
+}
+
 function importBabelPluginReactCompiler(
   workspaceFolder: string | undefined,
   babelPluginPath: string
@@ -199,15 +267,19 @@ function importBabelPluginReactCompiler(
   }
 
   if (workspaceFolder) {
-    try {
-      const plugin: PluginObj = require(path.join(workspaceFolder, babelPluginPath));
+    // The workspace search only runs when the root itself has no plugin, and
+    // its outcome is cached under `cacheKey` either way, so it costs at most
+    // one scan per root.
+    const plugin =
+      requirePlugin(path.join(workspaceFolder, babelPluginPath)) ??
+      requirePlugin(findPluginInWorkspace(workspaceFolder, babelPluginPath));
+    if (plugin) {
       pluginCache.set(cacheKey, plugin);
       return plugin;
-    } catch (error: any) {
-      throttledError(
-        `Failed to load babel-plugin-react-compiler from ${workspaceFolder}: ${error?.message}`
-      );
     }
+    throttledError(
+      `Failed to load babel-plugin-react-compiler from ${workspaceFolder} or any package below it`
+    );
   }
 
   // Fallback to the bundled version. Cache it under the root's key too, so a

--- a/packages/server/src/debounce.ts
+++ b/packages/server/src/debounce.ts
@@ -1,27 +1,62 @@
-const pending = new Map<string, { resolve: (value: null) => void; timer: NodeJS.Timeout }>();
+type Pending<T> = {
+  promise: Promise<T | null>;
+  resolve: (value: T | null) => void;
+  fn: () => T | null | Promise<T | null>;
+  timer: NodeJS.Timeout;
+};
 
+const pending = new Map<string, Pending<unknown>>();
+
+async function run(key: string): Promise<void> {
+  const entry = pending.get(key);
+  if (!entry) {
+    return;
+  }
+
+  // Drop the entry before awaiting, so a call arriving during the computation
+  // starts a fresh cycle instead of joining one that can no longer see it.
+  pending.delete(key);
+  try {
+    entry.resolve(await entry.fn());
+  } catch {
+    entry.resolve(null);
+  }
+}
+
+/**
+ * Coalesce calls that share a key: the timer restarts on every call, and every
+ * caller in the burst receives the single result that is finally computed.
+ *
+ * The burst must be shared rather than cancelled. A client that requests inlay
+ * hints in chunks (Zed asks for ~50 rows at a time) fires several
+ * near-simultaneous requests for one document; resolving all but the last with
+ * `null` would leave most of the file unmarked.
+ */
 export function debounce<T>(
   key: string,
   fn: () => T | null | Promise<T | null>,
   delayMs: number = 300
 ): Promise<T | null> {
-  const existing = pending.get(key);
+  const existing = pending.get(key) as Pending<T> | undefined;
   if (existing) {
     clearTimeout(existing.timer);
-    existing.resolve(null);
+    // The newest call sees the newest document, so it wins the computation.
+    existing.fn = fn;
+    existing.timer = setTimeout(() => run(key), delayMs);
+    return existing.promise;
   }
 
-  return new Promise((resolve) => {
-    const timer = setTimeout(async () => {
-      pending.delete(key);
-      try {
-        const result = await fn();
-        resolve(result);
-      } catch {
-        resolve(null);
-      }
-    }, delayMs);
-
-    pending.set(key, { resolve, timer });
+  let resolve!: (value: T | null) => void;
+  const promise = new Promise<T | null>((res) => {
+    resolve = res;
   });
+
+  pending.set(key, {
+    promise,
+    resolve,
+    fn,
+    timer: setTimeout(() => run(key), delayMs),
+  } as Pending<unknown>);
+
+  return promise;
 }

--- a/packages/server/src/inlayHints.ts
+++ b/packages/server/src/inlayHints.ts
@@ -1,4 +1,4 @@
-import { InlayHint, InlayHintKind, Position } from "vscode-languageserver/node";
+import { InlayHint, InlayHintKind, Position, Range } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { LoggerEvent } from "./checkReactCompiler";
 import { parseLog } from "./parseLog";
@@ -73,6 +73,34 @@ function getInlayHintPosition(
     position: Position.create(functionLine, hintPosition),
     functionName,
   };
+}
+
+// LSP ranges are start-inclusive and end-exclusive, so a hint sitting exactly
+// on a boundary belongs to the next chunk only.
+function isPositionInRange(position: Position, range: Range): boolean {
+  const afterStart =
+    position.line > range.start.line ||
+    (position.line === range.start.line && position.character >= range.start.character);
+  const beforeEnd =
+    position.line < range.end.line ||
+    (position.line === range.end.line && position.character < range.end.character);
+  return afterStart && beforeEnd;
+}
+
+/**
+ * Restrict hints to the range a request asked for.
+ *
+ * Hints are always computed for the whole document — that work is shared across
+ * a burst of requests for the same file — but `textDocument/inlayHint` names a
+ * range, and a client that asks for one (Zed requests ~50 rows at a time)
+ * discards everything outside it. An unclipped response therefore leaves the
+ * file unmarked.
+ */
+export function clipHintsToRange(hints: InlayHint[], range: Range | undefined): InlayHint[] {
+  if (!range) {
+    return hints;
+  }
+  return hints.filter((hint) => isPositionInRange(hint.position, range));
 }
 
 export function generateInlayHints(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,7 +22,7 @@ import {
   DEFAULT_COMPILATION_MODE,
   type CompilationMode,
 } from "./checkReactCompiler";
-import { generateInlayHints } from "./inlayHints";
+import { generateInlayHints, clipHintsToRange } from "./inlayHints";
 import { debounce } from "./debounce";
 import { shouldEnableHover } from "./clientUtils";
 import { resolveWorkspaceFolderForUri, workspaceFolderUriToPath } from "./workspaceFolders";
@@ -216,8 +216,10 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
     return null;
   }
 
-  // Use document URI as the debounce key
-  return debounce(params.textDocument.uri, () => {
+  // Use document URI as the debounce key. The debounced computation covers the
+  // whole document, so a burst of chunked requests for one file shares it; each
+  // request then keeps only the hints inside the range it asked for.
+  const hints = await debounce(params.textDocument.uri, () => {
     logMessage(`Process inlay hints for ${params.textDocument.uri}`);
     const fileName = params.textDocument.uri;
     const fileNameForCompiler = workspaceFolderUriToPath(fileName);
@@ -252,6 +254,8 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
       return null;
     }
   });
+
+  return hints && clipHintsToRange(hints, params.range);
 });
 
 // Handle hover request (only enabled for Neovim client, as VSCode/IntelliJ have native inlay hint hover)

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -24,7 +24,7 @@ import {
 } from "./checkReactCompiler";
 import { generateInlayHints, clipHintsToRange } from "./inlayHints";
 import { debounce } from "./debounce";
-import { shouldEnableHover } from "./clientUtils";
+import { shouldEnableHover, isZedClient } from "./clientUtils";
 import { resolveWorkspaceFolderForUri, workspaceFolderUriToPath } from "./workspaceFolders";
 
 import packageJson from "../package.json";
@@ -256,6 +256,18 @@ connection.languages.inlayHint.on(async (params: InlayHintParams): Promise<Inlay
   });
 
   return hints && clipHintsToRange(hints, params.range);
+});
+
+// Zed fetches hints for a newly started server through a refresh that does not
+// invalidate what it already has, so ranges another server (vtsls) filled while
+// this one was booting stay cached and this server is never asked about them
+// until the buffer is edited. Asking for a refresh once the document is open
+// invalidates just this server's hints and gets us queried.
+// Diagnosed by Isaac Hinman (isaachinman/zed-react-compiler-marker).
+documents.onDidOpen(() => {
+  if (isZedClient(clientName)) {
+    connection.languages.inlayHint.refresh();
+  }
 });
 
 // Handle hover request (only enabled for Neovim client, as VSCode/IntelliJ have native inlay hint hover)

--- a/packages/vscode-client/test/fixtures/dependency-only/App.tsx
+++ b/packages/vscode-client/test/fixtures/dependency-only/App.tsx
@@ -1,0 +1,3 @@
+export default function AppWithoutOwnPlugin() {
+  return <h1>Hello from a root whose only plugin belongs to a dependency</h1>;
+}

--- a/packages/vscode-client/test/fixtures/dependency-only/node_modules/some-dep/node_modules/babel-plugin-react-compiler/index.js
+++ b/packages/vscode-client/test/fixtures/dependency-only/node_modules/some-dep/node_modules/babel-plugin-react-compiler/index.js
@@ -1,0 +1,16 @@
+// A plugin nested inside a dependency's own node_modules. It belongs to that
+// dependency, not to this workspace, so the search must never pick it up.
+module.exports = function stubReactCompilerDependency(_api, options) {
+  return {
+    name: "stub-react-compiler-dependency",
+    visitor: {
+      Program() {
+        options?.logger?.logEvent("stub", {
+          kind: "CompileSuccess",
+          fnName: "stub-plugin-from-dependency",
+          fnLoc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        });
+      },
+    },
+  };
+};

--- a/packages/vscode-client/test/fixtures/dependency-only/node_modules/some-dep/node_modules/babel-plugin-react-compiler/package.json
+++ b/packages/vscode-client/test/fixtures/dependency-only/node_modules/some-dep/node_modules/babel-plugin-react-compiler/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "babel-plugin-react-compiler",
+  "version": "0.0.0-stub-dependency",
+  "main": "index.js"
+}

--- a/packages/vscode-client/test/fixtures/single-root/App.tsx
+++ b/packages/vscode-client/test/fixtures/single-root/App.tsx
@@ -1,0 +1,3 @@
+export default function AppInMonorepoRoot() {
+  return <h1>Hello from the monorepo root</h1>;
+}

--- a/packages/vscode-client/test/fixtures/single-root/apps/web/node_modules/babel-plugin-react-compiler/index.js
+++ b/packages/vscode-client/test/fixtures/single-root/apps/web/node_modules/babel-plugin-react-compiler/index.js
@@ -1,0 +1,17 @@
+// Stand-in for the plugin a sub-package of a monorepo installs. Only the
+// workspace search can find it: the single open root is the monorepo top, which
+// has no `node_modules/babel-plugin-react-compiler` of its own.
+module.exports = function stubReactCompilerAppsWeb(_api, options) {
+  return {
+    name: "stub-react-compiler-apps-web",
+    visitor: {
+      Program() {
+        options?.logger?.logEvent("stub", {
+          kind: "CompileSuccess",
+          fnName: "stub-plugin-from-apps-web",
+          fnLoc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        });
+      },
+    },
+  };
+};

--- a/packages/vscode-client/test/fixtures/single-root/apps/web/node_modules/babel-plugin-react-compiler/package.json
+++ b/packages/vscode-client/test/fixtures/single-root/apps/web/node_modules/babel-plugin-react-compiler/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "babel-plugin-react-compiler",
+  "version": "0.0.0-stub-apps-web",
+  "main": "index.js"
+}

--- a/packages/vscode-client/test/fixtures/single-root/apps/web/packages/inner/node_modules/babel-plugin-react-compiler/index.js
+++ b/packages/vscode-client/test/fixtures/single-root/apps/web/packages/inner/node_modules/babel-plugin-react-compiler/index.js
@@ -1,0 +1,16 @@
+// A second, deeper install. The breadth-first search must reach the one in
+// `apps/web` first, so this plugin should never run.
+module.exports = function stubReactCompilerInner(_api, options) {
+  return {
+    name: "stub-react-compiler-inner",
+    visitor: {
+      Program() {
+        options?.logger?.logEvent("stub", {
+          kind: "CompileSuccess",
+          fnName: "stub-plugin-from-inner",
+          fnLoc: { start: { line: 1, column: 0 }, end: { line: 1, column: 0 } },
+        });
+      },
+    },
+  };
+};

--- a/packages/vscode-client/test/fixtures/single-root/apps/web/packages/inner/node_modules/babel-plugin-react-compiler/package.json
+++ b/packages/vscode-client/test/fixtures/single-root/apps/web/packages/inner/node_modules/babel-plugin-react-compiler/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "babel-plugin-react-compiler",
+  "version": "0.0.0-stub-inner",
+  "main": "index.js"
+}

--- a/packages/vscode-client/test/inlayHintRequests.test.ts
+++ b/packages/vscode-client/test/inlayHintRequests.test.ts
@@ -1,0 +1,110 @@
+import * as assert from "assert";
+import * as path from "path";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+const serverOut = path.join(__dirname, "..", "..", "..", "server", "out");
+const { debounce } = require(path.join(serverOut, "debounce"));
+const { clipHintsToRange } = require(path.join(serverOut, "inlayHints"));
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const DELAY_MS = 10;
+
+function hintAt(line: number, character: number) {
+  return { position: { line, character }, label: "✨ " };
+}
+
+function range(startLine: number, startChar: number, endLine: number, endChar: number) {
+  return {
+    start: { line: startLine, character: startChar },
+    end: { line: endLine, character: endChar },
+  };
+}
+
+// A client that asks for a sub-range discards anything outside it, so hints
+// computed for the whole document have to be clipped before they are returned.
+suite("Inlay hints: clipping to the requested range", () => {
+  const hints = [hintAt(0, 5), hintAt(20, 0), hintAt(50, 0)];
+
+  test("keeps only the hints inside the range", () => {
+    assert.deepStrictEqual(clipHintsToRange(hints, range(0, 0, 50, 0)), [
+      hintAt(0, 5),
+      hintAt(20, 0),
+    ]);
+  });
+
+  test("the range end is exclusive, so a boundary hint belongs to the next chunk", () => {
+    assert.deepStrictEqual(clipHintsToRange(hints, range(50, 0, 100, 0)), [hintAt(50, 0)]);
+  });
+
+  test("the range start is inclusive", () => {
+    assert.deepStrictEqual(clipHintsToRange([hintAt(10, 4)], range(10, 4, 20, 0)), [hintAt(10, 4)]);
+    assert.deepStrictEqual(clipHintsToRange([hintAt(10, 3)], range(10, 4, 20, 0)), []);
+  });
+
+  test("returns everything when the client names no range", () => {
+    assert.deepStrictEqual(clipHintsToRange(hints, undefined), hints);
+  });
+});
+
+// Zed requests hints in ~50-row chunks, so one file produces a burst of
+// near-simultaneous requests. Cancelling all but the last leaves most of the
+// file unmarked. Diagnosed by Isaac Hinman
+// (isaachinman/zed-react-compiler-marker).
+suite("Inlay hints: debouncing a burst of requests", () => {
+  test("every caller in a burst receives the result", async () => {
+    let runs = 0;
+    const compute = () => {
+      runs++;
+      return ["hints"];
+    };
+
+    const results = await Promise.all([
+      debounce("file:///burst.tsx", compute, DELAY_MS),
+      debounce("file:///burst.tsx", compute, DELAY_MS),
+      debounce("file:///burst.tsx", compute, DELAY_MS),
+    ]);
+
+    assert.deepStrictEqual(results, [["hints"], ["hints"], ["hints"]]);
+    assert.strictEqual(runs, 1, "the burst must share one computation");
+  });
+
+  test("the newest call supplies the computation", async () => {
+    const [first, second] = await Promise.all([
+      debounce("file:///newest.tsx", () => "stale", DELAY_MS),
+      debounce("file:///newest.tsx", () => "fresh", DELAY_MS),
+    ]);
+
+    assert.strictEqual(first, "fresh", "an earlier caller still sees the newest document");
+    assert.strictEqual(second, "fresh");
+  });
+
+  test("different documents do not share a computation", async () => {
+    const [a, b] = await Promise.all([
+      debounce("file:///a.tsx", () => "a", DELAY_MS),
+      debounce("file:///b.tsx", () => "b", DELAY_MS),
+    ]);
+
+    assert.strictEqual(a, "a");
+    assert.strictEqual(b, "b");
+  });
+
+  test("a failing computation resolves null instead of rejecting", async () => {
+    const result = await debounce(
+      "file:///throws.tsx",
+      () => {
+        throw new Error("boom");
+      },
+      DELAY_MS
+    );
+
+    assert.strictEqual(result, null);
+  });
+
+  test("a later request starts a fresh computation", async () => {
+    const first = await debounce("file:///sequential.tsx", () => "first", DELAY_MS);
+    const second = await debounce("file:///sequential.tsx", () => "second", DELAY_MS);
+
+    assert.strictEqual(first, "first");
+    assert.strictEqual(second, "second");
+  });
+});

--- a/packages/vscode-client/test/multiRoot.test.ts
+++ b/packages/vscode-client/test/multiRoot.test.ts
@@ -190,6 +190,101 @@ suite("Multi-root workspace: plugin resolution", () => {
   });
 });
 
+// The common monorepo setup: one root at the top, the plugin installed only in
+// the sub-package that uses it. Diagnosed by Isaac Hinman
+// (isaachinman/zed-react-compiler-marker).
+suite("Single-root monorepo: plugin discovery below the root", () => {
+  const DEFAULT_PLUGIN_PATH = path.join("node_modules", "babel-plugin-react-compiler");
+
+  setup(() => {
+    clearPluginCache();
+    clearCompilationCache();
+  });
+
+  teardown(() => {
+    clearPluginCache();
+    clearCompilationCache();
+  });
+
+  test("finds a plugin a sub-package installed", () => {
+    const root = fixtureDir("single-root");
+    const source = fs.readFileSync(path.join(root, "App.tsx"), "utf8");
+
+    const result = checkReactCompiler(
+      source,
+      path.join(root, "App.tsx"),
+      root,
+      DEFAULT_PLUGIN_PATH,
+      "infer"
+    );
+
+    assert.strictEqual(
+      result.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-apps-web",
+      "the root has no plugin of its own, so apps/web's must be used"
+    );
+  });
+
+  test("the shallowest install wins", () => {
+    const root = fixtureDir("single-root");
+    const source = fs.readFileSync(path.join(root, "App.tsx"), "utf8");
+
+    const result = checkReactCompiler(
+      source,
+      path.join(root, "App.tsx"),
+      root,
+      DEFAULT_PLUGIN_PATH,
+      "infer"
+    );
+
+    assert.notStrictEqual(
+      result.successfulCompilations[0]?.fnName,
+      "stub-plugin-from-inner",
+      "a deeper install must not beat the one nearer the root"
+    );
+  });
+
+  test("does not descend into node_modules", () => {
+    const root = fixtureDir("dependency-only");
+    const source = fs.readFileSync(path.join(root, "App.tsx"), "utf8");
+
+    // The only plugin here belongs to a dependency, so the bundled compiler
+    // takes over rather than a package this workspace never asked for.
+    const result = checkReactCompiler(
+      source,
+      path.join(root, "App.tsx"),
+      root,
+      DEFAULT_PLUGIN_PATH,
+      "infer"
+    );
+
+    assert.ok(
+      !result.successfulCompilations.some((event: { fnName?: string }) =>
+        event.fnName?.startsWith("stub-plugin-from-")
+      ),
+      "a plugin inside a dependency's node_modules must never be picked up"
+    );
+  });
+
+  test("the search runs once per root, not once per file", () => {
+    const root = fixtureDir("single-root");
+    const pluginModule = path.join(root, "apps", "web", DEFAULT_PLUGIN_PATH);
+    const source = fs.readFileSync(path.join(root, "App.tsx"), "utf8");
+
+    checkReactCompiler(source, path.join(root, "one.tsx"), root, DEFAULT_PLUGIN_PATH, "infer");
+    const loadedOnce = require.cache[require.resolve(pluginModule)];
+    assert.ok(loadedOnce, "the discovered plugin should be in the require cache");
+
+    checkReactCompiler(source, path.join(root, "two.tsx"), root, DEFAULT_PLUGIN_PATH, "infer");
+
+    assert.strictEqual(
+      require.cache[require.resolve(pluginModule)],
+      loadedOnce,
+      "a second file must reuse the cached plugin instead of rescanning"
+    );
+  });
+});
+
 suite("Multi-root workspace: root resolution for a document", () => {
   const roots = ["/ws/project-a", "/ws/project-b"];
 
@@ -254,7 +349,10 @@ suite("Multi-root workspace: root resolution for a document", () => {
   });
 
   test("converts file:// URIs to paths", () => {
-    assert.strictEqual(workspaceFolderUriToPath("file:///ws/project-a"), path.sep + path.join("ws", "project-a"));
+    assert.strictEqual(
+      workspaceFolderUriToPath("file:///ws/project-a"),
+      path.sep + path.join("ws", "project-a")
+    );
     assert.strictEqual(
       workspaceFolderUriToPath("file:///ws/with%20space"),
       path.sep + path.join("ws", "with space")


### PR DESCRIPTION
Ports the fixes from [isaachinman/zed-react-compiler-marker](https://github.com/isaachinman/zed-react-compiler-marker), a credited MIT port of our Zed client. **Isaac Hinman diagnosed all three.**

That port wraps the LSP in a Node shim. Two of the three are real bugs in `packages/server` that affect every client, so they're fixed at the source here instead — no shim, no wrapper process.

## The three fixes

**1. `fix: find the compiler plugin in monorepo sub-packages`**

#86 fixed *multi-root* resolution. It doesn't cover the common case: one root at the monorepo top with `babel-plugin-react-compiler` installed only in a sub-package (`apps/web/node_modules/…`). The root-level require missed and we silently fell back to the compiler bundled into the server, so users got our pinned version instead of theirs.

`importBabelPluginReactCompiler` now tries the root's own plugin, then a bounded breadth-first search below the root, then the bundled fallback. Shallowest install wins. Never descends into `node_modules`/`dist`/`build`/`out`/`coverage`/`vendor` or dotdirs, and descends plain directories only (symlinks loop) — but *probes* through symlinks so pnpm layouts resolve. Capped at 5000 directories. No new cache: the existing per-scope `pluginCache` already makes it at most one scan per root.

Note this also applies to the CLI and report paths, which share the same function.

**2. `fix: clip inlay hints to the requested range`** — protocol correctness, client-agnostic

Two defects that compounded:
- The handler never read `params.range`, returning hints for the whole document, which a range-requesting client discards as out-of-range.
- `debounce` resolved the previous pending promise with `null` when a new request arrived on the same key. Zed requests hints in ~50-row chunks, so a burst for one file meant all but one resolved `null`.

Hints are now clipped to `params.range` (start-inclusive, end-exclusive), and `debounce` shares one computation across same-key callers instead of cancelling. The clipping had to move *outside* the debounce for this — a shared result can't be clipped to one caller's range.

**3. `fix: refresh inlay hints on didOpen for Zed`** — Zed-specific

Zed only fetches hints for a newly-started server via a non-invalidating refresh, so ranges already populated by vtsls stay cached and we're never queried until the buffer is edited. A `documents.onDidOpen` handler now sends `workspace/inlayHint/refresh`, gated on `isZedClient` via the existing `clientUtils` detection.

## Verification

I wrote a throwaway LSP harness that impersonates Zed against the real built `server.bundle.js` — single workspace root at a monorepo top, hints requested in 50-row chunks fired as one burst.

Against a bundle built from `main` it scores **1/6**. Against this branch, **6/6**:

```
PASS  no chunk is answered with null (debounce shares the computation)   0/8 chunks null
PASS  every chunk of a long file gets exactly the hints it should        16 hints across 8 chunks
PASS  no hint falls outside the range its chunk asked for                0 out-of-range hints
PASS  hints are not duplicated across chunk boundaries                   16 hints for 16 components
PASS  the project's own plugin ran, not the bundled fallback
PASS  Zed: inlay hint refresh requested after didOpen                    0 before, 1 after
```

So all three bugs reproduce on current `main` and are resolved.

Running the same harness as `"Visual Studio Code"` gives byte-identical hints plus command links, and no didOpen refresh — the gate works and fixes 1 and 3 don't regress VS Code.

Also: 13 new tests (4 plugin-discovery with fixture monorepos, 9 for clipping and debounce), full suite 47 passing, `tsc -b` / eslint / prettier clean, `cargo build --target wasm32-wasip1 --release` succeeds.

### Not verified end-to-end

- [ ] **Fix 3 in real Zed.** The harness proves the server *sends* the refresh; it can't prove Zed re-queries in response. Isaac found a single immediate refresh insufficient and used 100/1000/3000 ms retries against a Zed-side registration race. Ours fires later than his (after `initialize`), so it may well win — but that's reasoning, not evidence. To check: install as a dev extension, open an untouched buffer in a monorepo, confirm markers appear without editing. If they don't, bounded retries are a one-line follow-up.

## Separately: registry publishing is blocked today

While checking Isaac's rationale for downloading the server from a release, I confirmed it against [Zed's publishing prerequisites](https://github.com/zed-industries/zed/blob/main/docs/src/extensions/publishing/prerequisites.md):

> Extensions that intend to provide a language, debugger or MCP server **must not ship the language server as part of the extension**. Instead, the extension should either download the language server or check for the availability of the language server in the user's environment using the APIs as provided by the Zed Rust Extension API.

`packages/zed-client` currently embeds the 4.5 MB bundle via `include_bytes!`, which is exactly what's prohibited (and why the wasm is 4.3 MB). Dev-extension use is unaffected; only registry submission is blocked. Not addressed in this PR — needs a separate decision on adopting the release-asset flow.
