### PR TITLE
fix(cli): read --version from package.json and place skips at function start

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the React Compiler Marker CLI will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- `--version` now reports the installed package version instead of a hardcoded `1.0.0`
+- Skipped entries in the `text` report are now shown at the start of the function instead of on the `"use no memo"` directive line
 
 ---
 

--- a/packages/cli/src/formatText.ts
+++ b/packages/cli/src/formatText.ts
@@ -9,14 +9,16 @@ interface ParsedFailure {
   line: number | undefined;
 }
 
-function parseFailure(filePath: string, log: LogEntry): ParsedFailure {
-  const line =
+function parseFailure(filePath: string, log: LogEntry, preferFnLoc = false): ParsedFailure {
+  const detailLine =
     log.detail?.options?.details?.at(0)?.loc?.start?.line ??
     log.detail?.options?.loc?.start?.line ??
     log.detail?.loc?.start?.line ??
-    log.loc?.start?.line ??
-    log.fnLoc?.start?.line ??
-    undefined;
+    log.loc?.start?.line;
+  const fnLine = log.fnLoc?.start?.line;
+  // Skip events point `loc` at the "use no memo" directive; `fnLoc` is remapped
+  // to the function start, which is where the marker belongs.
+  const line = (preferFnLoc ? (fnLine ?? detailLine) : (detailLine ?? fnLine)) ?? undefined;
   const reason = log?.detail?.options?.reason || log?.reason || "Unknown reason";
   return { filePath, fnName: log.fnName, reason, line };
 }
@@ -63,7 +65,7 @@ export function formatText(report: ReactCompilerReport): string {
   const skips: ParsedFailure[] = [];
   for (const file of report.files) {
     for (const log of file.skipped ?? []) {
-      skips.push(parseFailure(file.path, log));
+      skips.push(parseFailure(file.path, log, true));
     }
   }
 

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -24,7 +24,8 @@ import {
 } from "@react-compiler-marker/server/src/report";
 import { formatText } from "./formatText";
 
-const VERSION = "1.0.0";
+const VERSION = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"))
+  .version as string;
 
 const HELP = `
 Usage: react-compiler-marker [options] [directory]


### PR DESCRIPTION
Two user-visible bugs found while verifying the CLI against `rcm-multi-root` and a real Expo monorepo. Both are live in the published `react-compiler-marker@0.2.0`.

### `--version` reported `1.0.0`

`main.ts` hardcoded `const VERSION = "1.0.0"`, while CI only bumps `package.json`. Every published build has reported `1.0.0`:

```
$ npx react-compiler-marker@0.2.0 --version
1.0.0
```

Now read from `package.json` at runtime. Works in both layouts — dev (`out/main.js` → `packages/cli/package.json`) and published (`dist/out/main.js` → `dist/package.json`, which `scripts/publish.js` writes with the bumped version). Verified against a simulated dist tree, not just locally.

### Skipped entries pointed at the directive line

#87 remapped `CompileSkip` events onto the function start, but `formatText.ts` read `log.loc` (the `"use no memo"` directive) before `log.fnLoc`, so the text report never showed the fix — only the JSON output did. This made the 0.2.0 release note about skip positions inaccurate.

Failures still prefer `detail.loc`, which is the precise error location and the right choice there; only skips prefer `fnLoc`.

On `packages/vscode-client/test/fixtures`:

```
- use-no-memo-multiline-signature.tsx:16    + use-no-memo-multiline-signature.tsx:11
- use-no-memo-multiline-signature.tsx:26    + use-no-memo-multiline-signature.tsx:21
- use-no-memo.tsx:5                         + use-no-memo.tsx:4
```

matching the expected lines in the fixture's own comments. The Failures section is byte-identical before and after.

### Checks

`typecheck`, `lint`, `prettier` clean; CLI rebuilt and re-run against the fixtures, `rcm-multi-root` (all three roots still resolve their own plugin), and a real monorepo.