### PR TITLE
chore(intellij): clear released entries from [Unreleased]

### DIFF
--- a/packages/intellij-client/CHANGELOG.md
+++ b/packages/intellij-client/CHANGELOG.md
@@ -3,15 +3,6 @@
 All notable changes to the React Compiler Marker WebStorm/IntelliJ plugin will be documented in this file.
 
 ## [Unreleased]
-### Added
-- **`"use no memo"` opt-outs**: Functions opted out of the compiler are now reported as skipped (configurable Skipped Emoji, default ⏭️) instead of being dropped from markers and reports
-- **Respect .gitignore**: New setting to honor .gitignore rules when scanning files for report generation (enabled by default)
-- **Compilation Mode**: New setting to choose the React Compiler `compilationMode` (`infer`, `annotation`, `syntax`, `all`) so markers match your project's configuration
-
-### Fixed
-- **Flow files**: `.js`/`.jsx`/`.mjs` files with a `@flow` pragma are now parsed with hermes-parser, so modern Flow syntax (`component`, `hook`, `renders`, `readonly`, `match`, `x is T`, …) no longer fails to parse and drop all markers — thanks @jonreading81
-- **Plugin and report resolution**: the React Compiler plugin and generated reports are now resolved relative to the project root
-- **Skipped marker position**: the skipped marker is now placed at the start of the function for multi-line signatures instead of drifting onto a later line
 
 ---
 


### PR DESCRIPTION
`intellij-v1.1.0` was tagged minutes before the workflow fix that clears `[Unreleased]` landed on main, so its entries were copied into `## [1.1.0]` and also left in `[Unreleased]`. This removes the duplicates.

Same cleanup that was applied to the VS Code changelog after `vscode-v2.3.0`, which missed the cutoff for the same reason. `cli-v0.2.0` was tagged after the fix and cleared correctly, so no future release needs this.

One entry that went out in 1.1.0's notes was stale regardless: **"Respect .gitignore"** had been sitting in `[Unreleased]` since it shipped in 1.0.1, so it appeared in both version sections. It stays in `[1.1.0]` here since that is what the published release notes say — worth knowing it was not actually new in 1.1.0.