### PR TITLE
feat(server): run extra babel plugins before the React Compiler

### DIFF
--- a/packages/nvim-client/README.md
+++ b/packages/nvim-client/README.md
@@ -63,6 +63,11 @@ require('react-compiler-marker').setup({
   -- Path to babel-plugin-react-compiler (relative to workspace root)
   babel_plugin_path = "node_modules/babel-plugin-react-compiler",
 
+  -- Babel plugins to run before babel-plugin-react-compiler, resolved from the
+  -- workspace root. Needed for macro expanders -- without them the marker
+  -- analyses the file as written and can report a bailout your build never hits.
+  extra_babel_plugins = {},
+
   -- Inlay hint settings
   inlay_hints = {
     enabled = true,

--- a/packages/nvim-client/lua/react-compiler-marker/config.lua
+++ b/packages/nvim-client/lua/react-compiler-marker/config.lua
@@ -29,6 +29,13 @@ M.defaults = {
   -- See https://react.dev/reference/react-compiler/compilationMode
   compilation_mode = "infer",
 
+  -- Babel plugins to run *before* babel-plugin-react-compiler, resolved from
+  -- the workspace root. Use this for macro expanders -- without them the
+  -- marker analyses the file as-written and can report a bailout the real
+  -- build never hits.
+  -- e.g. { "@lingui/babel-plugin-lingui-macro" }
+  extra_babel_plugins = {},
+
   -- Enable/disable on startup
   enabled = true,
 
@@ -131,6 +138,11 @@ function M.get_server_settings()
       skippedEmoji = M.config.emojis.skipped,
       babelPluginPath = M.config.babel_plugin_path,
       compilationMode = M.config.compilation_mode,
+      -- Omitted when empty: an empty Lua table encodes as a JSON object,
+      -- which the server would reject as a malformed list.
+      extraBabelPlugins = #M.config.extra_babel_plugins > 0
+          and M.config.extra_babel_plugins
+        or nil,
     },
   }
 end

--- a/packages/server/src/checkReactCompiler.ts
+++ b/packages/server/src/checkReactCompiler.ts
@@ -1,6 +1,7 @@
 import { PluginObj, transformSync } from "@babel/core";
 // @ts-expect-error - no types
 import BabelPluginSyntaxHermesParser from "babel-plugin-syntax-hermes-parser";
+import { createRequire } from "module";
 import * as path from "path";
 import { LRUCache } from "./cache";
 import { createSkipEventRemapper } from "./remapSkipEvents";
@@ -78,8 +79,109 @@ const HERMES_PARSER_OPTIONS = { parseLangTypes: "flow" };
 // every root after the first analyze its files with the wrong compiler.
 const pluginCache = new Map<string, PluginObj>();
 
+// Babel plugins that must run *before* the React Compiler -- macro expanders
+// such as @lingui/babel-plugin-lingui-macro. The compiler only ever sees the
+// file as-written, so an unexpanded macro can make it bail on syntax the real
+// build never emits (a tagged template with interpolations is the common
+// case), reporting a component as un-memoized when the bundle memoizes it fine.
+let extraBabelPlugins: ReadonlyArray<string> = [];
+
+export function setExtraBabelPlugins(plugins: ReadonlyArray<string>): void {
+  extraBabelPlugins = plugins;
+}
+
+export function normalizeExtraBabelPlugins(value: unknown): string[] {
+  if (value === undefined || value === null) {
+    return [];
+  }
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+    return value as string[];
+  }
+  // Some clients encode an empty list as an empty object; that is still "none".
+  if (typeof value === "object" && Object.keys(value as object).length === 0) {
+    return [];
+  }
+  throttledError(
+    `Invalid extraBabelPlugins "${JSON.stringify(value)}". Expected an array of module specifiers.`
+  );
+  return [];
+}
+
+// Resolved extra plugins, keyed by `${workspaceFolder}\0${specifier}`. `null`
+// marks a specifier that failed to load, so we do not retry it per file.
+const extraPluginCache = new Map<string, PluginObj | null>();
+
+/**
+ * Runs `run` with the process cwd set to `workspaceFolder`.
+ *
+ * Extra plugins are third-party macro expanders, and several of them (Lingui
+ * among others) find their own config by searching up from `process.cwd()` --
+ * which, for a language server, is wherever the editor was launched rather
+ * than the project being edited. Babel's own `cwd` option does not help: the
+ * plugin reads the real process cwd.
+ *
+ * Safe because the work inside is `transformSync` on a single-threaded
+ * runtime -- nothing else can run, and so nothing else can observe the
+ * swapped cwd, before it is restored. Only applied when extra plugins are
+ * configured, so the default path is untouched.
+ */
+function withWorkspaceCwd<T>(workspaceFolder: string | undefined, run: () => T): T {
+  if (!workspaceFolder || extraBabelPlugins.length === 0) {
+    return run();
+  }
+
+  const previousCwd = process.cwd();
+  if (previousCwd === workspaceFolder) {
+    return run();
+  }
+
+  process.chdir(workspaceFolder);
+  try {
+    return run();
+  } finally {
+    process.chdir(previousCwd);
+  }
+}
+
+function loadExtraBabelPlugins(workspaceFolder: string | undefined): Array<PluginObj> {
+  if (!workspaceFolder || extraBabelPlugins.length === 0) {
+    return [];
+  }
+
+  const workspaceRequire = createRequire(path.join(workspaceFolder, "package.json"));
+  const plugins: Array<PluginObj> = [];
+
+  for (const specifier of extraBabelPlugins) {
+    const cacheKey = `${workspaceFolder}\0${specifier}`;
+    let plugin = extraPluginCache.get(cacheKey);
+
+    if (plugin === undefined) {
+      try {
+        // resolve() honours the package's "exports" map; require()-ing the
+        // resolved file (rather than the specifier) is what lets ESM-only
+        // plugins load, via Node's require(esm) support.
+        const loaded = workspaceRequire(workspaceRequire.resolve(specifier));
+        plugin = (loaded?.default ?? loaded) as PluginObj;
+      } catch (error: any) {
+        throttledError(
+          `Failed to load extra babel plugin "${specifier}" from ${workspaceFolder}: ${error?.message}`
+        );
+        plugin = null;
+      }
+      extraPluginCache.set(cacheKey, plugin);
+    }
+
+    if (plugin) {
+      plugins.push(plugin);
+    }
+  }
+
+  return plugins;
+}
+
 export function clearPluginCache(): void {
   pluginCache.clear();
+  extraPluginCache.clear();
 }
 
 // Compilation result cache (50 entries max)
@@ -111,7 +213,8 @@ function runBabelPluginReactCompiler(
   text: string,
   file: string,
   language: "flow" | "typescript",
-  compilationMode: CompilationMode
+  compilationMode: CompilationMode,
+  extraPlugins: Array<PluginObj>
 ) {
   const successfulCompilations: Array<LoggerEvent> = [];
   const failedCompilations: Array<LoggerEvent> = [];
@@ -152,6 +255,11 @@ function runBabelPluginReactCompiler(
     retainLines: true,
     plugins: [
       [BabelPluginSyntaxHermesParser, HERMES_PARSER_OPTIONS],
+      // Macro expanders run first so the compiler sees the same tree the real
+      // build compiles. Babel merges every plugin into one traversal and
+      // visits a node in plugin order, so an expander with a Program visitor
+      // rewrites the tree before the compiler's Program visitor reads it.
+      ...extraPlugins,
       skipRemapper.plugin,
       [BabelPluginReactCompiler, COMPILER_OPTIONS],
     ],
@@ -183,7 +291,12 @@ const BUNDLED_PLUGIN_CACHE_KEY = "\0bundled";
  * plugin produced a given result.
  */
 function pluginScope(workspaceFolder: string | undefined, babelPluginPath: string): string {
-  return workspaceFolder ? `${workspaceFolder}\0${babelPluginPath}` : BUNDLED_PLUGIN_CACHE_KEY;
+  // The extra plugins change the tree the compiler sees, so results keyed
+  // without them would survive a settings change that invalidates them.
+  const extras = extraBabelPlugins.join(",");
+  return workspaceFolder
+    ? `${workspaceFolder}\0${babelPluginPath}\0${extras}`
+    : `${BUNDLED_PLUGIN_CACHE_KEY}\0${extras}`;
 }
 
 function importBabelPluginReactCompiler(
@@ -259,12 +372,15 @@ export function checkReactCompiler(
 
   try {
     const language = getLanguageFromFilename(filename);
-    const result = runBabelPluginReactCompiler(
-      BabelPluginReactCompiler,
-      sourceCode,
-      filename,
-      language,
-      compilationMode
+    const result = withWorkspaceCwd(workspaceFolder, () =>
+      runBabelPluginReactCompiler(
+        BabelPluginReactCompiler,
+        sourceCode,
+        filename,
+        language,
+        compilationMode,
+        loadExtraBabelPlugins(workspaceFolder)
+      )
     );
 
     // Cache the result
@@ -298,21 +414,24 @@ export async function getCompiledOutput(
 
   try {
     const language = getLanguageFromFilename(filename);
-    const result = transformSync(sourceCode, {
-      filename,
-      highlightCode: false,
-      retainLines: true,
-      plugins: [
-        [BabelPluginSyntaxHermesParser, HERMES_PARSER_OPTIONS],
-        [BabelPluginReactCompiler, { ...DEFAULT_COMPILER_OPTIONS, compilationMode }],
-      ],
-      parserOpts: {
-        plugins: language === "typescript" ? ["typescript", "jsx"] : ["flow", "jsx"],
-      },
-      sourceType: "module",
-      configFile: false,
-      babelrc: false,
-    });
+    const result = withWorkspaceCwd(workspaceFolder, () =>
+      transformSync(sourceCode, {
+        filename,
+        highlightCode: false,
+        retainLines: true,
+        plugins: [
+          [BabelPluginSyntaxHermesParser, HERMES_PARSER_OPTIONS],
+          ...loadExtraBabelPlugins(workspaceFolder),
+          [BabelPluginReactCompiler, { ...DEFAULT_COMPILER_OPTIONS, compilationMode }],
+        ],
+        parserOpts: {
+          plugins: language === "typescript" ? ["typescript", "jsx"] : ["flow", "jsx"],
+        },
+        sourceType: "module",
+        configFile: false,
+        babelrc: false,
+      })
+    );
 
     // eslint-disable-next-line eqeqeq
     if (result?.code == null) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -19,6 +19,8 @@ import {
   clearPluginCache,
   clearCompilationCache,
   normalizeCompilationMode,
+  normalizeExtraBabelPlugins,
+  setExtraBabelPlugins,
   DEFAULT_COMPILATION_MODE,
   type CompilationMode,
 } from "./checkReactCompiler";
@@ -52,6 +54,7 @@ interface Settings {
   skippedEmoji: string | null;
   babelPluginPath: string;
   compilationMode: CompilationMode;
+  extraBabelPlugins: string[];
 }
 
 let globalSettings: Settings = {
@@ -60,6 +63,7 @@ let globalSettings: Settings = {
   skippedEmoji: "⏭️",
   babelPluginPath: "node_modules/babel-plugin-react-compiler",
   compilationMode: DEFAULT_COMPILATION_MODE,
+  extraBabelPlugins: [],
 };
 
 // Tooltip format preference from client (markdown or html)
@@ -181,16 +185,22 @@ connection.onDidChangeConfiguration((change) => {
   const settings = change.settings?.reactCompilerMarker;
   if (settings) {
     const oldBabelPluginPath = globalSettings.babelPluginPath;
+    const oldExtraBabelPlugins = globalSettings.extraBabelPlugins.join(",");
     globalSettings = {
       successEmoji: settings.successEmoji ?? "✨",
       errorEmoji: settings.errorEmoji ?? "🚫",
       skippedEmoji: settings.skippedEmoji ?? "⏭️",
       babelPluginPath: settings.babelPluginPath ?? "node_modules/babel-plugin-react-compiler",
       compilationMode: normalizeCompilationMode(settings.compilationMode),
+      extraBabelPlugins: normalizeExtraBabelPlugins(settings.extraBabelPlugins),
     };
+    setExtraBabelPlugins(globalSettings.extraBabelPlugins);
 
-    // Clear caches if babel plugin path changed
-    if (oldBabelPluginPath !== globalSettings.babelPluginPath) {
+    // Clear caches if the babel plugin path or the extra plugins changed
+    if (
+      oldBabelPluginPath !== globalSettings.babelPluginPath ||
+      oldExtraBabelPlugins !== globalSettings.extraBabelPlugins.join(",")
+    ) {
       clearPluginCache();
       clearCompilationCache();
     }

--- a/packages/vscode-client/package.json
+++ b/packages/vscode-client/package.json
@@ -145,6 +145,14 @@
           "default": "node_modules/babel-plugin-react-compiler",
           "description": "Path to the babel-plugin-react-compiler in your project. By default it's 'node_modules/babel-plugin-react-compiler'"
         },
+        "reactCompilerMarker.extraBabelPlugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Babel plugins to run **before** `babel-plugin-react-compiler`, resolved from the workspace root. Use this for macro expanders (for example `@lingui/babel-plugin-lingui-macro`): the compiler only ever sees the file as written, so an unexpanded macro can make it bail on syntax your real build never emits."
+        },
         "reactCompilerMarker.respectGitignore": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
This code and PR was generated entirely by Claude Code. Feel free to take this as inspiration for your own implementation, I just wanted a quick fix for my Neovim

## Problem

The server analyses each file exactly as written: `checkReactCompiler` runs `transformSync` with a fixed plugin list and `configFile: false, babelrc: false`, so the project's Babel config never applies. For most projects that's correct and fast.

It diverges for **macro libraries**, whose syntax a Babel plugin rewrites before the compiler ever sees it. React Compiler bails on tagged templates with interpolations (facebook/react#35029), so with Lingui:

```tsx
const { t } = useLingui();
return <Text>{t`Hi ${name}`}</Text>;
```

the marker reports 🚫 *"Handle tagged template with interpolations"*, while the real build — where `@lingui/babel-plugin-lingui-macro` has already rewritten it into a plain call — memoizes the component fine. The same shape affects `styled-components` and `graphql-tag` style plugins.

## Change

A new setting, `extraBabelPlugins` (nvim: `extra_babel_plugins`, VS Code: `reactCompilerMarker.extraBabelPlugins`): module specifiers resolved from the workspace root and inserted **before** `babel-plugin-react-compiler`.

```lua
extra_babel_plugins = { "@lingui/babel-plugin-lingui-macro" },
```

Defaults to `[]`. When unset, nothing about the existing path changes.

### Implementation notes

- **Ordering works because Babel merges all plugins into a single traversal** and visits each node in plugin order — an expander with a `Program` visitor rewrites the tree before the compiler's `Program` visitor reads it. Extra plugins sit after the hermes-syntax plugin and before `skipRemapper`, so the remapper records post-expansion function locations, which are the ones the compiler reports.
- **Resolution is `createRequire(<root>/package.json).resolve(spec)`, then `require()` of the resolved file.** Resolving first honours the package's `exports` map, and requiring the resolved file is what lets ESM-only plugins load via Node's `require(esm)` support — `@lingui/babel-plugin-lingui-macro` has no `main`, so requiring the package directory fails outright. Cached per `(root, specifier)`; a load failure caches `null` so it isn't retried per file.
- **`process.cwd()` is swapped to the workspace root around the transform.** Several expanders (Lingui among them) locate their own config by searching up from the real process cwd, which for a language server is wherever the editor was launched. Babel's own `cwd` option doesn't help. It's safe here: the wrapped work is `transformSync` on a single-threaded runtime, so nothing can observe the swap before the `finally` restores it — and it only engages when extra plugins are configured.
- The compilation cache key includes the plugin list, and changing the setting clears both caches.

## Testing

Against a real Expo SDK 57 / React Native 0.86 project using Lingui v6, driving `checkReactCompiler` directly:

| file | `extraBabelPlugins: []` | `["@lingui/babel-plugin-lingui-macro"]` |
| --- | --- | --- |
| ``t`Hi ${name}` `` | 🚫 tagged template with interpolations | ✨ memoized |
| a screen with `<Trans>` / `<Plural>` | ✨ memoized | ✨ memoized |

The `[]` column matches pre-change behaviour exactly, and the second column matches what the project's real Babel pipeline produces (checked independently by running the project's own `babel.config.js` and looking for `_c(n)` in the output).

Also: `tsc -b`, `eslint`, and `prettier --check` clean; nvim bundle rebuilt via `scripts/build-nvim.sh` and smoke-tested through a real LSP `initialize` handshake (server starts, `inlayHintProvider` advertised). I have not driven the VS Code client end to end — that change is the declarative `contributes.configuration` entry only.

## Not included

Settings surfaces for `intellij-client` and `zed-client`.

### AI Disclaimer

This code and PR was generated entirely by Claude Code.